### PR TITLE
Fix SaveVersion()

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -797,9 +797,11 @@ func (ndb *nodeDB) saveRoot(hash []byte, version int64, flushToDisk bool) error 
 
 	key := ndb.rootKey(version)
 	ndb.updateLatestVersion(version)
-	ndb.recentBatch.Set(key, hash)
 	if flushToDisk {
 		ndb.snapshotBatch.Set(key, hash)
+		ndb.recentBatch.Delete(key)
+	} else {
+		ndb.recentBatch.Set(key, hash)
 	}
 
 	return nil

--- a/nodedb.go
+++ b/nodedb.go
@@ -231,15 +231,14 @@ func (ndb *nodeDB) saveNodeBatch(node *Node, flushToDisk bool, rb, sb dbm.Batch)
 		panic(err)
 	}
 
-	if !node.saved {
-		node.saved = true
-		rb.Set(ndb.nodeKey(node.hash), buf.Bytes())
-	}
-
 	if flushToDisk {
 		sb.Set(ndb.nodeKey(node.hash), buf.Bytes())
+		rb.Delete(ndb.nodeKey(node.hash))
 		node.persisted = true
 		node.saved = true
+	} else if !node.saved {
+		node.saved = true
+		rb.Set(ndb.nodeKey(node.hash), buf.Bytes())
 	}
 }
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -797,11 +797,9 @@ func (ndb *nodeDB) saveRoot(hash []byte, version int64, flushToDisk bool) error 
 
 	key := ndb.rootKey(version)
 	ndb.updateLatestVersion(version)
+	ndb.recentBatch.Set(key, hash)
 	if flushToDisk {
 		ndb.snapshotBatch.Set(key, hash)
-		ndb.recentBatch.Delete(key)
-	} else {
-		ndb.recentBatch.Set(key, hash)
 	}
 
 	return nil


### PR DESCRIPTION
When saving on snapshot version, delete flushed nodes and root hash from recentDB.

#256 