### PR TITLE
use separate batch for snapshot orphans

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -549,7 +549,7 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		// There can still be orphans, for example if the root is the node being
 		// removed.
 		debug("SAVE EMPTY TREE %v\n", version)
-		if err := tree.ndb.SaveOrphans(version, tree.orphans); err != nil {
+		if err := tree.ndb.SaveOrphans(version, tree.orphans, true); err != nil {
 			panic(err)
 		}
 
@@ -563,7 +563,7 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 			panic(err)
 		}
 
-		if err := tree.ndb.SaveOrphans(version, tree.orphans); err != nil {
+		if err := tree.ndb.SaveOrphans(version, tree.orphans, true); err != nil {
 			panic(err)
 		}
 
@@ -651,7 +651,7 @@ func (tree *MutableTree) DeleteVersion(version int64) error {
 		return err
 	}
 
-	if err := tree.ndb.Commit(vm.Snapshot); err != nil {
+	if err := tree.ndb.Commit(false); err != nil {
 		return err
 	}
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -549,25 +549,25 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		// There can still be orphans, for example if the root is the node being
 		// removed.
 		debug("SAVE EMPTY TREE %v\n", version)
-		if err := tree.ndb.SaveOrphans(version, tree.orphans, true); err != nil {
+		if err := tree.ndb.SaveOrphans(version, tree.orphans, vm.Snapshot, true); err != nil {
 			panic(err)
 		}
 
-		if err := tree.ndb.SaveEmptyRoot(version); err != nil {
+		if err := tree.ndb.SaveEmptyRoot(version, vm.Snapshot); err != nil {
 			panic(err)
 		}
 	} else {
 		debug("SAVE TREE %v\n", version)
 
-		if _, err := tree.ndb.SaveTree(tree.root, version); err != nil {
+		if _, err := tree.ndb.SaveTree(tree.root, version, vm.Snapshot); err != nil {
 			panic(err)
 		}
 
-		if err := tree.ndb.SaveOrphans(version, tree.orphans, true); err != nil {
+		if err := tree.ndb.SaveOrphans(version, tree.orphans, vm.Snapshot, true); err != nil {
 			panic(err)
 		}
 
-		if err := tree.ndb.SaveRoot(tree.root, version); err != nil {
+		if err := tree.ndb.SaveRoot(tree.root, version, vm.Snapshot); err != nil {
 			panic(err)
 		}
 	}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -572,7 +572,7 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		}
 	}
 
-	if err := tree.ndb.Commit(); err != nil {
+	if err := tree.ndb.Commit(vm.Snapshot); err != nil {
 		return nil, version, err
 	}
 
@@ -620,7 +620,7 @@ func (tree *MutableTree) pruneRecentVersion() error {
 		}
 
 		delete(tree.versions, prunedVersion)
-		return tree.ndb.Commit()
+		return tree.ndb.Commit(false)
 	}
 
 	return nil
@@ -651,7 +651,7 @@ func (tree *MutableTree) DeleteVersion(version int64) error {
 		return err
 	}
 
-	if err := tree.ndb.Commit(); err != nil {
+	if err := tree.ndb.Commit(vm.Snapshot); err != nil {
 		return err
 	}
 
@@ -706,7 +706,7 @@ func (tree *MutableTree) deleteVersionsFrom(version int64) error {
 
 	tree.ndb.restoreNodes(newLatestVersion)
 
-	if err := tree.ndb.Commit(); err != nil {
+	if err := tree.ndb.Commit(false); err != nil {
 		return err
 	}
 

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -289,7 +289,7 @@ func TestDeleteVersion_issue261(t *testing.T) {
 		require.NoError(t, err)
 
 		// Load the latest persisted version.
-		version, err := tree.LoadVersion(0)
+		_, err = tree.LoadVersion(0)
 		require.NoError(t, err)
 
 		// Create new versions.
@@ -300,7 +300,7 @@ func TestDeleteVersion_issue261(t *testing.T) {
 				tree.Set(key, value)
 			}
 
-			_, version, err = tree.SaveVersion()
+			_, version, err := tree.SaveVersion()
 			require.NoError(t, err)
 
 			// Delete the previous keepEvery version if it's a multiple of KeepEvery. This follows

--- a/nodedb.go
+++ b/nodedb.go
@@ -400,16 +400,13 @@ func (ndb *nodeDB) saveOrphan(hash []byte, fromVersion, toVersion int64, flushTo
 	if fromVersion > toVersion {
 		panic(fmt.Sprintf("Orphan expires before it comes alive.  %d > %d", fromVersion, toVersion))
 	}
+	key := ndb.orphanKey(fromVersion, toVersion, hash)
 
 	if ndb.isRecentVersion(toVersion) {
-		key := ndb.orphanKey(fromVersion, toVersion, hash)
 		ndb.recentBatch.Set(key, hash)
 	}
 
 	if flushToDisk {
-		// save to disk with toVersion equal to snapshotVersion closest to original toVersion
-		snapVersion := toVersion - (toVersion % ndb.opts.KeepEvery)
-		key := ndb.orphanKey(fromVersion, snapVersion, hash)
 		if queue {
 			ndb.snapshotOrphanBatch.Set(key, hash)
 		} else {

--- a/pruning_test.go
+++ b/pruning_test.go
@@ -291,7 +291,7 @@ func TestSanity1(t *testing.T) {
 	for i := 1; i < 5; i++ {
 		err := mt.ndb.DeleteVersionFromRecent(int64(i), true)
 		require.NoError(t, err)
-		err = mt.ndb.Commit()
+		err = mt.ndb.Commit(false)
 		require.NoError(t, err)
 	}
 


### PR DESCRIPTION
Fixes #261. I tried several approaches, this is the simplest one that passes all current tests.

I found it hard to reason about the interactions between orphaning and pruning, and am concerned that this only adds to the complexity, and thus the potential for harmful interactions. I will write a comprehensive, randomized stress test in a separate PR.