### PR TITLE
test: fix random failure in TestVersionedTreeProofs

### DIFF
--- a/testutils_test.go
+++ b/testutils_test.go
@@ -32,7 +32,7 @@ func b2i(bz []byte) int {
 
 // Construct a MutableTree with random pruning parameters
 func getTestTree(cacheSize int) (*MutableTree, error) {
-	keepRecent := mrand.Int63n(8) + 2        //keep at least 2 versions in memDB
+	keepRecent := mrand.Int63n(8) + 3        //keep at least 3 versions in memDB
 	keepEvery := (mrand.Int63n(3) + 1) * 100 // snapshot every {100,200,300} versions
 
 	opts := PruningOptions(keepEvery, keepRecent)

--- a/tree_test.go
+++ b/tree_test.go
@@ -1010,7 +1010,8 @@ func TestVersionedTreeProofs(t *testing.T) {
 	tree.Set([]byte("k1"), []byte("v1"))
 	tree.Set([]byte("k2"), []byte("v1"))
 	tree.Set([]byte("k3"), []byte("v1"))
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
 	// fmt.Println("TREE VERSION 1")
 	// printNode(tree.ndb, tree.root, 0)
@@ -1020,7 +1021,8 @@ func TestVersionedTreeProofs(t *testing.T) {
 
 	tree.Set([]byte("k2"), []byte("v2"))
 	tree.Set([]byte("k4"), []byte("v2"))
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
 	// fmt.Println("TREE VERSION 2")
 	// printNode(tree.ndb, tree.root, 0)
@@ -1030,7 +1032,8 @@ func TestVersionedTreeProofs(t *testing.T) {
 	require.NotEqual(root1, root2)
 
 	tree.Remove([]byte("k2"))
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
 	// fmt.Println("TREE VERSION 3")
 	// printNode(tree.ndb, tree.root, 0)


### PR DESCRIPTION
`TestVersionedTreeProofs` uses a tree with random pruning settings. This has a 12.5% chance to generate a tree which will delete versions that the test needs. The RNG defaults to `Seed(1)`, so this failure only happens if we change the sequence of tests relying on the RNG.