### PR TITLE
fix LoadVersionForOverwriting data corruption

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -195,8 +195,8 @@ func (ndb *nodeDB) DeleteVersionsFrom(version int64) error {
 	if err != nil {
 		return err
 	}
-	if len(root) == 0 {
-		return errors.New("root for version %v not found")
+	if root == nil {
+		return errors.Errorf("root for version %v not found", latest)
 	}
 
 	for v, r := range ndb.versionReaders {

--- a/nodedb.go
+++ b/nodedb.go
@@ -5,6 +5,7 @@ import (
 	"container/list"
 	"crypto/sha256"
 	"fmt"
+	"math"
 	"sort"
 	"sync"
 
@@ -184,6 +185,85 @@ func (ndb *nodeDB) DeleteVersion(version int64, checkLatestVersion bool) error {
 	return nil
 }
 
+// DeleteVersionsFrom permanently deletes all tree versions from the given version upwards.
+func (ndb *nodeDB) DeleteVersionsFrom(version int64) error {
+	latest := ndb.getLatestVersion()
+	if latest < version {
+		return nil
+	}
+	root, err := ndb.getRoot(latest)
+	if err != nil {
+		return err
+	}
+	if len(root) == 0 {
+		return errors.New("root for version %v not found")
+	}
+
+	for v, r := range ndb.versionReaders {
+		if v >= version && r != 0 {
+			return errors.Errorf("unable to delete version %v with %v active readers", v, r)
+		}
+	}
+
+	// First, delete all active nodes in the current (latest) version whose node version is after
+	// the given version.
+	err = ndb.deleteNodesFrom(version, root)
+	if err != nil {
+		return err
+	}
+
+	// Next, delete orphans:
+	// - Delete orphan entries *and referred nodes* with fromVersion >= version
+	// - Delete orphan entries with toVersion >= version
+	ndb.traverseOrphans(func(k, v []byte) {
+		var fromVersion, toVersion int64
+		orphanKeyFormat.Scan(k, &toVersion, &fromVersion)
+
+		if fromVersion >= version {
+			ndb.batch.Delete(k)
+			ndb.batch.Delete(v)
+			ndb.uncacheNode(v)
+		} else if toVersion >= version {
+			ndb.batch.Delete(k)
+		}
+	})
+
+	// Finally, delete the version root entries
+	ndb.traverseRange(rootKeyFormat.Key(version), rootKeyFormat.Key(math.MaxInt64), func(k, v []byte) {
+		fmt.Printf("Delete root %x %x\n", k, v)
+		ndb.batch.Delete(k)
+	})
+
+	return nil
+}
+
+// deleteNodesFrom deletes the given node and any descendants that have versions after the given
+// (inclusive). It is mainly used via LoadVersionForOverwriting, to delete the current version.
+func (ndb *nodeDB) deleteNodesFrom(version int64, hash []byte) error {
+	if len(hash) == 0 {
+		return nil
+	}
+
+	node := ndb.GetNode(hash)
+	if node.leftHash != nil {
+		if err := ndb.deleteNodesFrom(version, node.leftHash); err != nil {
+			return err
+		}
+	}
+	if node.rightHash != nil {
+		if err := ndb.deleteNodesFrom(version, node.rightHash); err != nil {
+			return err
+		}
+	}
+
+	if node.version >= version {
+		ndb.batch.Delete(ndb.nodeKey(hash))
+		ndb.uncacheNode(hash)
+	}
+
+	return nil
+}
+
 // Saves orphaned nodes to disk under a special prefix.
 // version: the new version being saved.
 // orphans: the orphan nodes created since version-1
@@ -309,7 +389,12 @@ func (ndb *nodeDB) traverseOrphansVersion(version int64, fn func(k, v []byte)) {
 
 // Traverse all keys.
 func (ndb *nodeDB) traverse(fn func(key, value []byte)) {
-	itr, err := ndb.db.Iterator(nil, nil)
+	ndb.traverseRange(nil, nil, fn)
+}
+
+// Traverse all keys between a given range (excluding end).
+func (ndb *nodeDB) traverseRange(start []byte, end []byte, fn func(k, v []byte)) {
+	itr, err := ndb.db.Iterator(start, end)
 	if err != nil {
 		panic(err)
 	}

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -17,13 +17,13 @@ import (
 func TestRandomOperations(t *testing.T) {
 	seeds := []int64{
 		49872768941,
-		/*756509998,
+		756509998,
 		480459882,
 		32473644,
 		581827344,
 		470870060,
 		390970079,
-		846023066,*/
+		846023066,
 	}
 
 	for _, seed := range seeds {
@@ -41,13 +41,13 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		keySize   = 16 // before base64-encoding
 		valueSize = 16 // before base64-encoding
 
-		versions     = 32  // number of final versions to generate
-		reloadChance = 0.2 // chance of tree reload after save
-		deleteChance = 0.2 // chance of random version deletion after save
-		revertChance = 0.1 // chance to revert tree to random version with LoadVersionForOverwriting
-		syncChance   = 0.3 // chance of enabling sync writes on tree load
-		cacheChance  = 0.4 // chance of enabling caching
-		cacheSizeMax = 256 // maximum size of cache (will be random from 1)
+		versions     = 32   // number of final versions to generate
+		reloadChance = 0.1  // chance of tree reload after save
+		deleteChance = 0.2  // chance of random version deletion after save
+		revertChance = 0.05 // chance to revert tree to random version with LoadVersionForOverwriting
+		syncChance   = 0.2  // chance of enabling sync writes on tree load
+		cacheChance  = 0.4  // chance of enabling caching
+		cacheSizeMax = 256  // maximum size of cache (will be random from 1)
 
 		versionOps  = 64  // number of operations (create/update/delete) per version
 		updateRatio = 0.4 // ratio of updates out of all operations
@@ -171,25 +171,25 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		if r.Float64() < revertChance {
 			versions := getMirrorVersions(diskMirrors, memMirrors)
 			if len(versions) > 1 {
-				target := int64(versions[r.Intn(len(versions)-1)])
-				t.Logf("Reverting to version %v", target)
-				_, err = tree.LoadVersionForOverwriting(target)
-				require.NoError(t, err, "Failed to revert to version %v", target)
-				if m, ok := diskMirrors[target]; ok {
+				version = int64(versions[r.Intn(len(versions)-1)])
+				t.Logf("Reverting to version %v", version)
+				_, err = tree.LoadVersionForOverwriting(version)
+				require.NoError(t, err, "Failed to revert to version %v", version)
+				if m, ok := diskMirrors[version]; ok {
 					mirror = copyMirror(m)
-				} else if m, ok := memMirrors[target]; ok {
+				} else if m, ok := memMirrors[version]; ok {
 					mirror = copyMirror(m)
 				} else {
-					t.Fatalf("Mirror not found for revert target %v", target)
+					t.Fatalf("Mirror not found for revert target %v", version)
 				}
 				mirrorKeys = getMirrorKeys(mirror)
 				for v := range diskMirrors {
-					if v > target {
+					if v > version {
 						delete(diskMirrors, v)
 					}
 				}
 				for v := range memMirrors {
-					if v > target {
+					if v > version {
 						delete(memMirrors, v)
 					}
 				}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1438,17 +1438,20 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	require := require.New(t)
 
-	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil)
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil)
+	require.NoError(err)
 
 	for i := byte(0); i < 20; i++ {
 		tree.Set([]byte{i}, []byte{i})
 	}
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
 	for i := byte(0); i < 20; i++ {
 		tree.Set([]byte{i}, []byte{i + 1})
 	}
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
 	removedNodes := []*Node{}
 
@@ -1461,12 +1464,14 @@ func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	for i := byte(0); i < 20; i++ {
 		tree.Remove([]byte{i})
 	}
-	tree.SaveVersion()
+	_, _, err = tree.SaveVersion()
+	require.NoError(err)
 
-	_, err := tree.LoadVersionForOverwriting(1)
+	_, err = tree.LoadVersionForOverwriting(1)
 	require.NoError(err)
 	for _, n := range removedNodes {
-		has, _ := tree.ndb.Has(n.hash)
+		has, err := tree.ndb.Has(n.hash)
+		require.NoError(err)
 		require.False(has, "LoadVersionForOverwriting should remove useless nodes")
 	}
 


### PR DESCRIPTION
Fixes #273, caused by faulty orphan removal.

Branched off of #274, merge that first.