### PR TITLE
lint: update golangci-lint to 1.29

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,6 @@ jobs:
       - uses: golangci/golangci-lint-action@master
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.27
+          version: v1.29
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
CI currently fails since 1.27 is unsupported.