### PR TITLE
add MutableTree.SetInitialVersion()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - [\#296](https://github.com/cosmos/iavl/pull/296) Add `iavlserver`, a gRPC/REST API server.
 
+- [\#312](https://github.com/cosmos/iavl/pull/312) Add `MutableTree.SetInitialVersion()` to set the 
+  initial version after tree initialization.
+
 ### Bug Fixes
 
 - [\#309](https://github.com/cosmos/iavl/pull/309) Fix `SaveVersion()` for old, empty versions as 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -527,6 +527,13 @@ func (tree *MutableTree) deleteVersion(version int64) error {
 	return nil
 }
 
+// SetInitialVersion sets the initial version of the tree, replacing Options.InitialVersion.
+// It is only used during the initial SaveVersion() call for a tree with no other versions,
+// and is otherwise ignored.
+func (tree *MutableTree) SetInitialVersion(version uint64) {
+	tree.ndb.opts.InitialVersion = version
+}
+
 // DeleteVersions deletes a series of versions from the MutableTree. An error
 // is returned if any single version is invalid or the delete fails. All writes
 // happen in a single batch with a single commit.

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -147,6 +147,18 @@ func TestMutableTree_InitialVersion(t *testing.T) {
 	assert.EqualValues(t, 11, version)
 }
 
+func TestMutableTree_SetInitialVersion(t *testing.T) {
+	memDB := db.NewMemDB()
+	tree, err := NewMutableTree(memDB, 0)
+	require.NoError(t, err)
+	tree.SetInitialVersion(9)
+
+	tree.Set([]byte("a"), []byte{0x01})
+	_, version, err := tree.SaveVersion()
+	require.NoError(t, err)
+	assert.EqualValues(t, 9, version)
+}
+
 func BenchmarkMutableTree_Set(b *testing.B) {
 	db, err := db.NewDB("test", db.MemDBBackend, "")
 	require.NoError(b, err)

--- a/nodedb.go
+++ b/nodedb.go
@@ -38,7 +38,7 @@ type nodeDB struct {
 	mtx            sync.Mutex       // Read/write lock.
 	db             dbm.DB           // Persistent node storage.
 	batch          dbm.Batch        // Batched writing buffer.
-	opts           *Options         // Options to customize for pruning/writing
+	opts           Options          // Options to customize for pruning/writing
 	versionReaders map[int64]uint32 // Number of active version readers
 
 	latestVersion  int64
@@ -49,12 +49,13 @@ type nodeDB struct {
 
 func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 	if opts == nil {
-		opts = DefaultOptions()
+		o := DefaultOptions()
+		opts = &o
 	}
 	return &nodeDB{
 		db:             db,
 		batch:          db.NewBatch(),
-		opts:           opts,
+		opts:           *opts,
 		latestVersion:  0, // initially invalid
 		nodeCache:      make(map[string]*list.Element),
 		nodeCacheSize:  cacheSize,

--- a/options.go
+++ b/options.go
@@ -13,6 +13,6 @@ type Options struct {
 }
 
 // DefaultOptions returns the default options for IAVL.
-func DefaultOptions() *Options {
-	return &Options{}
+func DefaultOptions() Options {
+	return Options{}
 }


### PR DESCRIPTION
Requested in https://github.com/cosmos/cosmos-sdk/pull/7089#issuecomment-680877202.

I didn't add a `GetInitialVersion()`, since it's not clear whether this should return only the option or the _actual_ initial version that exists in a tree.

It might be cleaner to add `GetOptions()`, `SetOptions()`, and `UpdateOptions(func (o Options) Options)`, but we may not want all options to be mutable after construction.

CC @amaurymartiny