### PR TITLE
fix: constant overflow when compiling for 32bit machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [\#318](https://github.com/cosmos/iavl/pull/318) fix: constant overflow when compiling for 32bit machines
+
 ### Breaking Changes
 
 - [\#317](https://github.com/cosmos/iavl/pull/317) `LoadVersion()` and `LazyLoadVersion()` now error 

--- a/nodedb.go
+++ b/nodedb.go
@@ -238,7 +238,7 @@ func (ndb *nodeDB) DeleteVersionsFrom(version int64) error {
 	})
 
 	// Finally, delete the version root entries
-	ndb.traverseRange(rootKeyFormat.Key(version), rootKeyFormat.Key(math.MaxInt64), func(k, v []byte) {
+	ndb.traverseRange(rootKeyFormat.Key(version), rootKeyFormat.Key(int64(math.MaxInt64)), func(k, v []byte) {
 		if err := ndb.batch.Delete(k); err != nil {
 			panic(err)
 		}

--- a/repair.go
+++ b/repair.go
@@ -41,7 +41,7 @@ func Repair013Orphans(db dbm.DB) (uint64, error) {
 	)
 	batch := db.NewBatch()
 	defer batch.Close()
-	ndb.traverseRange(orphanKeyFormat.Key(version), orphanKeyFormat.Key(math.MaxInt64), func(k, v []byte) {
+	ndb.traverseRange(orphanKeyFormat.Key(version), orphanKeyFormat.Key(int64(math.MaxInt64)), func(k, v []byte) {
 		// Sanity check so we don't remove stuff we shouldn't
 		var toVersion int64
 		orphanKeyFormat.Scan(k, &toVersion)


### PR DESCRIPTION
on Go 1.x(x) all constants are ints by default which causing
build for 32bit machines to fail due to overflow
https://github.com/golang/go/issues/23086