### PR TITLE
check version<0 in deleteVersion

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -516,7 +516,7 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 }
 
 func (tree *MutableTree) deleteVersion(version int64) error {
-	if version == 0 {
+	if version <= 0 {
 		return errors.New("version must be greater than 0")
 	}
 	if version == tree.version {


### PR DESCRIPTION
Fixes #345. This would cause an error in any case, since the version does not exist, but it's better to catch it here.