### PR TITLE
convertVarIntToBytes: use reusable bytes array not expensive, discarded bytes.Buffer

### DIFF
--- a/encoding_test.go
+++ b/encoding_test.go
@@ -86,3 +86,37 @@ func TestDecodeBytes_invalidVarint(t *testing.T) {
 	_, _, err := decodeBytes([]byte{0xff})
 	require.Error(t, err)
 }
+
+// sink is kept as a global to ensure that value checks and assignments to it can't be
+// optimized away, and this will help us ensure that benchmarks successfully run.
+var sink interface{}
+
+func BenchmarkConvertLeafOp(b *testing.B) {
+	var versions = []int64{
+		0,
+		1,
+		100,
+		127,
+		128,
+		1 << 29,
+		-0,
+		-1,
+		-100,
+		-127,
+		-128,
+		-1 << 29,
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, version := range versions {
+			sink = convertLeafOp(version)
+		}
+	}
+	if sink == nil {
+		b.Fatal("Benchmark wasn't run")
+	}
+	sink = nil
+}


### PR DESCRIPTION
Noticed while auditing and profiling dependencies of cosmos-sdk, that
convertVarIntToBytes, while reusing already implemented code, it
was expensively creating a bytes.Buffer (40B on 64-bit architectures)
returning a result and discarding it, yet that code was called
3 times successively at least.

By reusing a byte array (not a slice, to ensure bounds checks
eliminations by the compiler), we are able to dramatically improve
performance, taking it from ~4µs down to 850ns (~4.5X reduction),
reduce allocations by >=~80% in every dimension:

```shell
$ benchstat before.txt after.txt
name             old time/op    new time/op    delta
ConvertLeafOp-8    3.90µs ± 1%    0.85µs ± 4%  -78.12%  (p=0.000 n=10+10)

name             old alloc/op   new alloc/op   delta
ConvertLeafOp-8    5.18kB ± 0%    0.77kB ± 0%  -85.19%  (p=0.000 n=10+10)

name             old allocs/op  new allocs/op  delta
ConvertLeafOp-8       120 ± 0%        24 ± 0%  -80.00%  (p=0.000 n=10+10)
```

Fixes #344