### PR TITLE
github: don't login to Docker Hub on pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Otherwise PRs from forks will fail, as they don't have access to Github secrets. Login is only needed to push images, and images aren't pushed for pull requests anyway.