### PR TITLE
fix: Make GetVersioned() available after doing LazyLoadVersion

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -323,7 +323,11 @@ func (tree *MutableTree) LazyLoadVersion(targetVersion int64) (int64, error) {
 	iTree := &ImmutableTree{
 		ndb:     tree.ndb,
 		version: targetVersion,
-		root:    tree.ndb.GetNode(rootHash),
+	}
+	if len(rootHash) > 0 {
+		// If rootHash is empty then root of tree should be nil
+		// This makes `LazyLoadVersion` to do the same thing as `LoadVersion`
+		iTree.root = tree.ndb.GetNode(rootHash)
 	}
 
 	tree.orphans = map[string]int64{}

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -358,3 +358,25 @@ func TestMutableTree_DeleteVersion(t *testing.T) {
 	// cannot delete latest version
 	require.Error(t, tree.DeleteVersion(2))
 }
+
+func TestMutableTree_LazyLoadVersionWithEmptyTree(t *testing.T) {
+	mdb := db.NewMemDB()
+	tree, err := NewMutableTree(mdb, 1000)
+	require.NoError(t, err)
+	_, v1, err := tree.SaveVersion()
+	require.NoError(t, err)
+
+	newTree1, err := NewMutableTree(mdb, 1000)
+	require.NoError(t, err)
+	v2, err := newTree1.LazyLoadVersion(1)
+	require.NoError(t, err)
+	require.True(t, v1 == v2)
+
+	newTree2, err := NewMutableTree(mdb, 1000)
+	require.NoError(t, err)
+	v2, err = newTree1.LoadVersion(1)
+	require.NoError(t, err)
+	require.True(t, v1 == v2)
+
+	require.True(t, newTree1.root == newTree2.root)
+}

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -288,3 +288,73 @@ func BenchmarkMutableTree_Set(b *testing.B) {
 		t.Set(randBytes(10), []byte{})
 	}
 }
+
+func prepareTree(t *testing.T) *MutableTree {
+	mdb := db.NewMemDB()
+	tree, err := NewMutableTree(mdb, 1000)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		tree.Set([]byte{byte(i)}, []byte("a"))
+	}
+	_, ver, err := tree.SaveVersion()
+	require.True(t, ver == 1)
+	require.NoError(t, err)
+	for i := 0; i < 100; i++ {
+		tree.Set([]byte{byte(i)}, []byte("b"))
+	}
+	_, ver, err = tree.SaveVersion()
+	require.True(t, ver == 2)
+	require.NoError(t, err)
+	newTree, err := NewMutableTree(mdb, 1000)
+	require.NoError(t, err)
+
+	return newTree
+}
+
+func TestMutableTree_VersionExists(t *testing.T) {
+	tree := prepareTree(t)
+	require.True(t, tree.VersionExists(1))
+	require.True(t, tree.VersionExists(2))
+	require.False(t, tree.VersionExists(3))
+}
+
+func checkGetVersioned(t *testing.T, tree *MutableTree, version, index int64, key, value []byte) {
+	idx, val := tree.GetVersioned(key, version)
+	require.True(t, idx == index)
+	require.True(t, bytes.Equal(val, value))
+}
+
+func TestMutableTree_GetVersioned(t *testing.T) {
+	tree := prepareTree(t)
+	ver, err := tree.LazyLoadVersion(1)
+	require.True(t, ver == 1)
+	require.NoError(t, err)
+	// check key of unloaded version
+	checkGetVersioned(t, tree, 1, 1, []byte{1}, []byte("a"))
+	checkGetVersioned(t, tree, 2, 1, []byte{1}, []byte("b"))
+	checkGetVersioned(t, tree, 3, -1, []byte{1}, nil)
+
+	tree = prepareTree(t)
+	ver, err = tree.LazyLoadVersion(2)
+	require.True(t, ver == 2)
+	require.NoError(t, err)
+	checkGetVersioned(t, tree, 1, 1, []byte{1}, []byte("a"))
+	checkGetVersioned(t, tree, 2, 1, []byte{1}, []byte("b"))
+	checkGetVersioned(t, tree, 3, -1, []byte{1}, nil)
+}
+
+func TestMutableTree_DeleteVersion(t *testing.T) {
+	tree := prepareTree(t)
+	ver, err := tree.LazyLoadVersion(2)
+	require.True(t, ver == 2)
+	require.NoError(t, err)
+
+	require.NoError(t, tree.DeleteVersion(1))
+
+	require.False(t, tree.VersionExists(1))
+	require.True(t, tree.VersionExists(2))
+	require.False(t, tree.VersionExists(3))
+
+	// cannot delete latest version
+	require.Error(t, tree.DeleteVersion(2))
+}

--- a/nodedb.go
+++ b/nodedb.go
@@ -543,6 +543,10 @@ func (ndb *nodeDB) Commit() error {
 	return nil
 }
 
+func (ndb *nodeDB) HasRoot(version int64) (bool, error) {
+	return ndb.db.Has(ndb.rootKey(version))
+}
+
 func (ndb *nodeDB) getRoot(version int64) ([]byte, error) {
 	return ndb.db.Get(ndb.rootKey(version))
 }

--- a/proof_range.go
+++ b/proof_range.go
@@ -541,7 +541,7 @@ func (t *ImmutableTree) GetRangeWithProof(startKey []byte, endKey []byte, limit 
 // GetVersionedWithProof gets the value under the key at the specified version
 // if it exists, or returns nil.
 func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byte, *RangeProof, error) {
-	if tree.versions[version] {
+	if tree.VersionExists(version) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, err
@@ -557,7 +557,7 @@ func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byt
 func (tree *MutableTree) GetVersionedRangeWithProof(startKey, endKey []byte, limit int, version int64) (
 	keys, values [][]byte, proof *RangeProof, err error) {
 
-	if tree.versions[version] {
+	if tree.VersionExists(version) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
I recreate a PR again in place of https://github.com/cosmos/iavl/pull/358.

We can use LazyLoadVersion by #148.
But if we start app with LazyLoadVersion we cannot query app state by specific height because MutableTree.GetVersioned returns nil for other previous version after doing LazyLoadVersion.

Our nodes are facing a slow booting up problem because of the large app data, and I want to hear your opinion about whether we should modify the code like this.
