### PR TITLE
add "prefix" arg to iaviewer

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Login to DockerHub
         if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1
+        uses: docker/login-action@v1.9.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 
 ## Unreleased
-
+- [\#396](https://github.com/cosmos/iavl/pull/396) Add "prefix" arg to iaviewer.
 
 
 ## 0.16.0 (May 04, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 
 ## Unreleased
+
+### CLI Breaking Changes
+
 - [\#396](https://github.com/cosmos/iavl/pull/396) Add "prefix" arg to iaviewer.
 
 

--- a/cmd/iaviewer/README.md
+++ b/cmd/iaviewer/README.md
@@ -39,7 +39,7 @@ Now, if you run `ls -l`, you should see two directories... `bns-a.db` and `bns-b
 ### Inspecting available versions
 
 ```shell
-iaviewer versions ./bns-a.db
+iaviewer versions ./bns-a.db ""
 ```
 
 This should print out a list of 20 versions of the code. Note the the iavl tree will persist multiple
@@ -52,8 +52,8 @@ of the cases, we will consider only the last two versions, 190257 (last one wher
 First run these two and take a quick a look at the output:
 
 ```shell
-iaviewer data ./bns-a.db
-iaviewer data ./bns-a.db 190257
+iaviewer data ./bns-a.db ""
+iaviewer data ./bns-a.db "" 190257
 ```
 
 Notice you see the different heights and there is a change in size and app hash.
@@ -61,8 +61,8 @@ That's what happens when we process a transaction. Let's go further and use
 the handy tool `diff` to compare two states.
 
 ```shell
-iaviewer data ./bns-a.db 190257 > a-last.data
-iaviewer data ./bns-b.db 190257 > b-last.data
+iaviewer data ./bns-a.db "" 190257 > a-last.data
+iaviewer data ./bns-b.db "" 190257 > b-last.data
 
 diff a-last.data b-last.data
 ```
@@ -71,8 +71,8 @@ Same, same :)
 But if we take the current version...
 
 ```shell
-iaviewer data ./bns-a.db 190258 > a-cur.data
-iaviewer data ./bns-b.db 190258 > b-cur.data
+iaviewer data ./bns-a.db "" 190258 > a-cur.data
+iaviewer data ./bns-b.db "" 190258 > b-cur.data
 
 diff a-cur.data b-cur.data
 ```
@@ -97,8 +97,8 @@ but different hashes. This must be due to the shape of the iavl tree.
 To confirm that, and possibly get more insights, there is another command.
 
 ```shell
-iaviewer shape ./bns-a.db 190258 > a-cur.shape
-iaviewer shape ./bns-b.db 190258 > b-cur.shape
+iaviewer shape ./bns-a.db "" 190258 > a-cur.shape
+iaviewer shape ./bns-b.db "" 190258 > b-cur.shape
 diff a-cur.shape b-cur.shape
 ```
 

--- a/cmd/iaviewer/README.md
+++ b/cmd/iaviewer/README.md
@@ -99,6 +99,7 @@ To confirm that, and possibly get more insights, there is another command.
 ```shell
 iaviewer shape ./bns-a.db "" 190258 > a-cur.shape
 iaviewer shape ./bns-b.db "" 190258 > b-cur.shape
+
 diff a-cur.shape b-cur.shape
 ```
 

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -109,7 +109,7 @@ func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error)
 	if err != nil {
 		return nil, err
 	}
-	if len(prefix) != nil {
+	if len(prefix) != 0 {
 		db = dbm.NewPrefixDB(db, prefix)
 	}
 

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -103,12 +103,13 @@ func PrintDBStats(db dbm.DB) {
 
 // ReadTree loads an iavl tree from the directory
 // If version is 0, load latest, otherwise, load named version
+// The prefix represents which iavl tree you want to read. The iaviwer will always set a prefix.
 func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error) {
 	db, err := OpenDB(dir)
 	if err != nil {
 		return nil, err
 	}
-	if prefix != nil {
+	if len(prefix) != nil {
 		db = dbm.NewPrefixDB(db, prefix)
 	}
 

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -20,22 +20,24 @@ const (
 
 func main() {
 	args := os.Args[1:]
-	if len(args) < 2 || (args[0] != "data" && args[0] != "shape" && args[0] != "versions") {
-		fmt.Fprintln(os.Stderr, "Usage: iaviewer <data|shape|versions> <leveldb dir> [version number]")
+	if len(args) < 3 || (args[0] != "data" && args[0] != "shape" && args[0] != "versions") {
+		fmt.Fprintln(os.Stderr, "Usage: iaviewer <data|shape|versions> <leveldb dir> <prefix> [version number]")
+		fmt.Fprintln(os.Stderr, "<prefix> is the prefix of db, and the iavl tree of different modules in cosmos-sdk uses ")
+		fmt.Fprintln(os.Stderr, "different <prefix> to identify, just like \"s/k:gov/\" represents the prefix of gov module")
 		os.Exit(1)
 	}
 
 	version := 0
-	if len(args) == 3 {
+	if len(args) == 4 {
 		var err error
-		version, err = strconv.Atoi(args[2])
+		version, err = strconv.Atoi(args[3])
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Invalid version number: %s\n", err)
 			os.Exit(1)
 		}
 	}
 
-	tree, err := ReadTree(args[1], version)
+	tree, err := ReadTree(args[1], version, []byte(args[2]))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
 		os.Exit(1)
@@ -101,11 +103,15 @@ func PrintDBStats(db dbm.DB) {
 
 // ReadTree loads an iavl tree from the directory
 // If version is 0, load latest, otherwise, load named version
-func ReadTree(dir string, version int) (*iavl.MutableTree, error) {
+func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error) {
 	db, err := OpenDB(dir)
 	if err != nil {
 		return nil, err
 	}
+	if prefix != nil {
+		db = dbm.NewPrefixDB(db, prefix)
+	}
+
 	tree, err := iavl.NewMutableTree(db, DefaultCacheSize)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The pr can support access to the data in the iavl tree of different modules of cosmos-sdk

In cosmos-sdk, the different modules under x/ use different iavl trees and are stored in the same leveldb (application.db). Different db prefixes are used to distinguish different modules, such as "s/k: gov/", "s/k:staking/", "s/k:evm/".