### PR TITLE
Reduce encodeVarint memory usage

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -7,7 +7,14 @@ import (
 	"fmt"
 	"io"
 	"math/bits"
+	"sync"
 )
+
+var varintPool = &sync.Pool{
+	New: func() interface{} {
+		return &[binary.MaxVarintLen64]byte{}
+	},
+}
 
 // decodeBytes decodes a varint length-prefixed byte slice, returning it along with the number
 // of input bytes read.
@@ -108,7 +115,17 @@ func encodeUvarintSize(u uint64) int {
 
 // encodeVarint writes a varint-encoded integer to an io.Writer.
 func encodeVarint(w io.Writer, i int64) error {
-	var buf [binary.MaxVarintLen64]byte
+	// Use a pool here to reduce allocations.
+	//
+	// Though this allocates just 10 bytes on the stack, doing allocation for every calls
+	// cost us a huge memory. The profiling show that using pool save us ~30% memory.
+	//
+	// Since when we don't have concurrent access to the pool, the speed will nearly identical.
+	// If we need to support concurrent access, we can accept a *[binary.MaxVarintLen64]byte as
+	// input, so the caller can allocate just one and pass the same array pointer to each call.
+	buf := varintPool.Get().(*[binary.MaxVarintLen64]byte)
+	defer varintPool.Put(buf)
+
 	n := binary.PutVarint(buf[:], i)
 	_, err := w.Write(buf[0:n])
 	return err


### PR DESCRIPTION
By using a sync.Pool to shared temporary buffer between calls.

```
name                             old time/op    new time/op    delta
Export-8                           7.88ms ± 2%    7.91ms ± 1%     ~     (p=0.356 n=9+10)
Import-8                           9.01ms ± 7%    8.88ms ± 1%     ~     (p=0.529 n=10+10)
Node_WriteBytes/NoPreAllocate-8     340ns ± 5%     235ns ± 5%  -30.80%  (p=0.000 n=10+10)
Node_WriteBytes/PreAllocate-8       274ns ± 5%     204ns ± 0%  -25.49%  (p=0.000 n=10+8)

name                             old alloc/op   new alloc/op   delta
Export-8                           3.74MB ± 0%    3.74MB ± 0%     ~     (p=0.796 n=10+10)
Import-8                           9.84MB ± 0%    9.05MB ± 0%   -7.98%  (p=0.000 n=10+10)
Node_WriteBytes/NoPreAllocate-8      368B ± 0%      320B ± 0%  -13.04%  (p=0.000 n=10+10)
Node_WriteBytes/PreAllocate-8        224B ± 0%      176B ± 0%  -21.43%  (p=0.000 n=10+10)

name                             old allocs/op  new allocs/op  delta
Export-8                            69.6k ± 0%     69.6k ± 0%     ~     (all equal)
Import-8                             164k ± 0%      115k ± 0%  -29.88%  (p=0.000 n=10+10)
Node_WriteBytes/NoPreAllocate-8      9.00 ± 0%      6.00 ± 0%  -33.33%  (p=0.000 n=10+10)
Node_WriteBytes/PreAllocate-8        8.00 ± 0%      5.00 ± 0%  -37.50%  (p=0.000 n=10+10)
```

Fixes #419