### PR TITLE
rollback nodeDB to use normal mutex

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -36,7 +36,7 @@ var (
 )
 
 type nodeDB struct {
-	mtx            sync.RWMutex     // Read/write lock.
+	mtx            sync.Mutex       // Read/write lock.
 	db             dbm.DB           // Persistent node storage.
 	batch          dbm.Batch        // Batched writing buffer.
 	opts           Options          // Options to customize for pruning/writing
@@ -68,8 +68,8 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 // GetNode gets a node from memory or disk. If it is an inner node, it does not
 // load its children.
 func (ndb *nodeDB) GetNode(hash []byte) *Node {
-	ndb.mtx.RLock()
-	defer ndb.mtx.RUnlock()
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
 
 	if len(hash) == 0 {
 		panic("nodeDB.GetNode() requires hash")


### PR DESCRIPTION
close #427 
#428  previous update contains wrong RWMutext update for nodedb cache, which leads https://github.com/cosmos/cosmos-sdk/pull/10040/checks?check_run_id=3475312162 issue.

To prevent concurrent read write map access in nodedb, this PR rollback RWMutex to normal Mutex. 