### PR TITLE
Refactor Get() to work with new faster cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ cpu*.out
 mem*.out
 cpu*.pdf
 mem*.pdf
+
+# IDE files
+.idea/*

--- a/fast_node.go
+++ b/fast_node.go
@@ -15,15 +15,16 @@ type FastNode struct {
 }
 
 // NewFastNode returns a new fast node from a value and version.
-func NewFastNode(value []byte, version int64) *FastNode {
+func NewFastNode(key []byte, value []byte, version int64) *FastNode {
 	return &FastNode{
+		key:                  key,
 		versionLastUpdatedAt: version,
 		value:                value,
 	}
 }
 
-// MakeFastNode constructs an *FastNode from an encoded byte slice.
-func MakeFastNode(buf []byte) (*FastNode, error) {
+// DeserializeFastNode constructs an *FastNode from an encoded byte slice.
+func DeserializeFastNode(buf []byte) (*FastNode, error) {
 	val, n, cause := decodeBytes(buf)
 	if cause != nil {
 		return nil, errors.Wrap(cause, "decoding fastnode.value")
@@ -35,7 +36,10 @@ func MakeFastNode(buf []byte) (*FastNode, error) {
 		return nil, errors.Wrap(cause, "decoding fastnode.version")
 	}
 
-	fastNode := NewFastNode(val, ver)
+	fastNode := &FastNode{
+		versionLastUpdatedAt: ver,
+		value:                val,
+	}
 
 	return fastNode, nil
 }

--- a/fast_node.go
+++ b/fast_node.go
@@ -1,0 +1,41 @@
+package iavl
+
+import (
+	"github.com/pkg/errors"
+)
+
+// NOTE: This file favors int64 as opposed to int for size/counts.
+// The Tree on the other hand favors int.  This is intentional.
+
+type FastNode struct {
+	key                  []byte
+	versionLastUpdatedAt int64
+	value                []byte
+	leafHash             []byte // TODO: Look into if this would help with proof stuff.
+}
+
+// NewFastNode returns a new fast node from a value and version.
+func NewFastNode(value []byte, version int64) *FastNode {
+	return &FastNode{
+		versionLastUpdatedAt: version,
+		value:                value,
+	}
+}
+
+// MakeFastNode constructs an *FastNode from an encoded byte slice.
+func MakeFastNode(buf []byte) (*FastNode, error) {
+	val, n, cause := decodeBytes(buf)
+	if cause != nil {
+		return nil, errors.Wrap(cause, "decoding fastnode.value")
+	}
+	buf = buf[n:]
+
+	ver, _, cause := decodeVarint(buf)
+	if cause != nil {
+		return nil, errors.Wrap(cause, "decoding fastnode.version")
+	}
+
+	fastNode := NewFastNode(val, ver)
+
+	return fastNode, nil
+}

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -164,9 +164,8 @@ func (t *ImmutableTree) Get(key []byte) (index int64, value []byte) {
 
 	if fastNode.versionLastUpdatedAt > t.version {
 		return t.root.get(t, key)
-	} else {
-		return 0, value // TODO determine index and adjust this appropriately
 	}
+	return 0, value // TODO determine index and adjust this appropriately
 }
 
 // GetByIndex gets the key and value at the specified index.

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -146,19 +146,26 @@ func (t *ImmutableTree) Export() *Exporter {
 // otherwise. The returned value must not be modified, since it may point to data stored within
 // IAVL.
 // TODO: Understand what is this index? Index on its own isn't well defined
-// index across all leaves?
+// index = index of the leaf node
 func (t *ImmutableTree) Get(key []byte) (index int64, value []byte) {
 	if t.root == nil {
 		return 0, nil
 	}
-	// IMPLEMENT FOLLOWING PSUEDOCODE
-	// value, version := t.nodeDb.fastGet(key)
-	// if value == nil { return t.root.get(t, key)}
-	// if version > t.version { return t.root.get(t, key)}
-	// else: return value
-	// TODO: Figure out what index is
 
-	return t.root.get(t, key)
+	fastNode := t.ndb.GetFastNode(key)
+	if fastNode == nil {
+		return t.root.get(t, key)
+	}
+	value = fastNode.value
+	if value == nil {
+		return t.root.get(t, key)
+	}
+
+	if fastNode.versionLastUpdatedAt > t.version {
+		return t.root.get(t, key)
+	} else {
+		return 0, value // TODO determine index and adjust this appropriately
+	}
 }
 
 // GetByIndex gets the key and value at the specified index.

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -145,8 +145,9 @@ func (t *ImmutableTree) Export() *Exporter {
 // Get returns the index and value of the specified key if it exists, or nil and the next index
 // otherwise. The returned value must not be modified, since it may point to data stored within
 // IAVL.
-// TODO: Understand what is this index? Index on its own isn't well defined
-// index = index of the leaf node
+//
+// The index is the index in the list of leaf nodes sorted lexicographically by key. The leftmost leaf has index 0.
+// It's neighbor has index 1 and so on.
 func (t *ImmutableTree) Get(key []byte) (index int64, value []byte) {
 	if t.root == nil {
 		return 0, nil

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -152,8 +152,8 @@ func (t *ImmutableTree) Get(key []byte) (index int64, value []byte) {
 		return 0, nil
 	}
 
-	fastNode := t.ndb.GetFastNode(key)
-	if fastNode == nil {
+	fastNode, err := t.ndb.GetFastNode(key)
+	if fastNode == nil || err != nil {
 		return t.root.get(t, key)
 	}
 	value = fastNode.value

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -162,6 +162,7 @@ func (t *ImmutableTree) Get(key []byte) (index int64, value []byte) {
 		return t.root.get(t, key)
 	}
 
+	// cache node is too new, so read from historical tree
 	if fastNode.versionLastUpdatedAt > t.version {
 		return t.root.get(t, key)
 	}

--- a/node.go
+++ b/node.go
@@ -157,6 +157,9 @@ func (node *Node) has(t *ImmutableTree, key []byte) (has bool) {
 }
 
 // Get a key under the node.
+//
+// The index is the index in the list of leaf nodes sorted lexicographically by key. The leftmost leaf has index 0.
+// It's neighbor has index 1 and so on.
 func (node *Node) get(t *ImmutableTree, key []byte) (index int64, value []byte) {
 	if node.isLeaf() {
 		switch bytes.Compare(node.key, key) {

--- a/nodedb.go
+++ b/nodedb.go
@@ -144,7 +144,7 @@ func (ndb *nodeDB) GetFastNode(key []byte) (*FastNode, error) {
 		return nil, fmt.Errorf("Value missing for key %x ", key)
 	}
 
-	fastNode, err := MakeFastNode(buf)
+	fastNode, err := DeserializeFastNode(buf)
 	if err != nil {
 		return nil, fmt.Errorf("Error reading FastNode. bytes: %x, error: %v ", buf, err)
 	}

--- a/nodedb.go
+++ b/nodedb.go
@@ -56,6 +56,10 @@ type nodeDB struct {
 	nodeCache      map[string]*list.Element // Node cache.
 	nodeCacheSize  int                      // Node cache size limit in elements.
 	nodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
+
+	fastNodeCache      map[string]*list.Element // FastNode cache.
+	fastNodeCacheSize  int                      // FastNode cache size limit in elements.
+	fastNodeCacheQueue *list.List               // LRU queue of cache elements. Used for deletion.
 }
 
 func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
@@ -64,14 +68,17 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options) *nodeDB {
 		opts = &o
 	}
 	return &nodeDB{
-		db:             db,
-		batch:          db.NewBatch(),
-		opts:           *opts,
-		latestVersion:  0, // initially invalid
-		nodeCache:      make(map[string]*list.Element),
-		nodeCacheSize:  cacheSize,
-		nodeCacheQueue: list.New(),
-		versionReaders: make(map[int64]uint32, 8),
+		db:                 db,
+		batch:              db.NewBatch(),
+		opts:               *opts,
+		latestVersion:      0, // initially invalid
+		nodeCache:          make(map[string]*list.Element),
+		nodeCacheSize:      cacheSize,
+		nodeCacheQueue:     list.New(),
+		fastNodeCache:      make(map[string]*list.Element),
+		fastNodeCacheSize:  cacheSize,
+		fastNodeCacheQueue: list.New(),
+		versionReaders:     make(map[int64]uint32, 8),
 	}
 }
 
@@ -111,6 +118,40 @@ func (ndb *nodeDB) GetNode(hash []byte) *Node {
 	ndb.cacheNode(node)
 
 	return node
+}
+
+func (ndb *nodeDB) GetFastNode(key []byte) *FastNode {
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
+
+	if len(key) == 0 {
+		panic("nodeDB.GetFastNode() requires key")
+	}
+
+	// Check the cache.
+	if elem, ok := ndb.fastNodeCache[string(key)]; ok {
+		// Already exists. Move to back of fastNodeCacheQueue.
+		ndb.fastNodeCacheQueue.MoveToBack(elem)
+		return elem.Value.(*FastNode)
+	}
+
+	// Doesn't exist, load.
+	buf, err := ndb.db.Get(key)
+	if err != nil {
+		panic(fmt.Sprintf("can't get fast-node %X: %v", key, err))
+	}
+	if buf == nil {
+		panic(fmt.Sprintf("Value missing for key %x ", key))
+	}
+
+	fastNode, err := MakeFastNode(buf)
+	if err != nil {
+		panic(fmt.Sprintf("Error reading FastNode. bytes: %x, error: %v", buf, err))
+	}
+
+	fastNode.key = key
+	ndb.cacheFastNode(fastNode)
+	return fastNode
 }
 
 // SaveNode saves a node to disk.
@@ -550,6 +591,26 @@ func (ndb *nodeDB) cacheNode(node *Node) {
 		oldest := ndb.nodeCacheQueue.Front()
 		hash := ndb.nodeCacheQueue.Remove(oldest).(*Node).hash
 		delete(ndb.nodeCache, string(hash))
+	}
+}
+
+func (ndb *nodeDB) uncacheFastNode(key []byte) {
+	if elem, ok := ndb.fastNodeCache[string(key)]; ok {
+		ndb.fastNodeCacheQueue.Remove(elem)
+		delete(ndb.fastNodeCache, string(key))
+	}
+}
+
+// Add a node to the cache and pop the least recently used node if we've
+// reached the cache size limit.
+func (ndb *nodeDB) cacheFastNode(node *FastNode) {
+	elem := ndb.fastNodeCacheQueue.PushBack(node)
+	ndb.fastNodeCache[string(node.key)] = elem
+
+	if ndb.fastNodeCacheQueue.Len() > ndb.fastNodeCacheSize {
+		oldest := ndb.fastNodeCacheQueue.Front()
+		key := ndb.fastNodeCacheQueue.Remove(oldest).(*FastNode).key
+		delete(ndb.fastNodeCache, string(key))
 	}
 }
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -128,6 +128,7 @@ func (ndb *nodeDB) GetFastNode(key []byte) (*FastNode, error) {
 		panic("nodeDB.GetFastNode() requires key")
 	}
 
+	// TODO make a second write lock just for fastNodeCacheQueue later
 	// Check the cache.
 	if elem, ok := ndb.fastNodeCache[string(key)]; ok {
 		// Already exists. Move to back of fastNodeCacheQueue.
@@ -141,12 +142,12 @@ func (ndb *nodeDB) GetFastNode(key []byte) (*FastNode, error) {
 		return nil, fmt.Errorf("can't get fast-node %X: %v", key, err)
 	}
 	if buf == nil {
-		return nil, fmt.Errorf("Value missing for key %x ", key)
+		return nil, fmt.Errorf("value missing for key %x ", key)
 	}
 
 	fastNode, err := DeserializeFastNode(buf)
 	if err != nil {
-		return nil, fmt.Errorf("Error reading FastNode. bytes: %x, error: %v ", buf, err)
+		return nil, fmt.Errorf("error reading FastNode. bytes: %x, error: %v ", buf, err)
 	}
 
 	fastNode.key = key


### PR DESCRIPTION
Created a new cache in `nodedb.go` that would be maintained for our newer `FastNode` structs and implemented the pieces necessary for changing `Get()` as per [this](https://github.com/cosmos/iavl/commit/75d6e9829a4a29b1b2fe02d0f2ead3dd7ae9388d#diff-f53b00cecfca17dc100d06e79d2ce350e3b92c09d33fe69d384feaba56d2aa40R154-R160)