### PR TITLE
fix: remove unnecessary (*bytes.Buffer).Reset right after creating buffer

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -163,7 +163,6 @@ func BenchmarkNode_WriteBytes(b *testing.B) {
 		sub.ReportAllocs()
 		for i := 0; i < sub.N; i++ {
 			var buf bytes.Buffer
-			buf.Reset()
 			_ = node.writeBytes(&buf)
 		}
 	})


### PR DESCRIPTION
After a bytes.Buffer has been freshly created, there is no need to
invoke .Reset.

Fixes #451