### PR TITLE
perf: use a reusable bytes.Buffer to speed up MutableTree.String

### DIFF
--- a/with_gcc_test.go
+++ b/with_gcc_test.go
@@ -1,3 +1,4 @@
+//go:build gcc
 // +build gcc
 
 // This file exists because some of the DBs e.g CLevelDB


### PR DESCRIPTION
The prior code used a naive string concatenation
str += "..."

which is very slow and inefficient especially when iterating over
all the keys, but also it performed an unnecessary byteslice->string
conversion for all arguments inside (nodeDB).traverse* using

    str += fmt.Sprintf("%s: %x\n", string(key), value)

notice the `string(key)` passed into fmt.Sprintf("%s"?
At bare minimum that code should just simply be:

    str += fmt.Sprintf("%s: %x\n", key, value)

per https://twitter.com/orijtech/status/1462100381803102213?s=20
which saves a whole lot of cycles and RAM.

This change uses:
* (*bytes.Buffer) in combination with fmt.Fprintf
* A sync.Pool with (*bytes.Buffer) values to reuse buffers

and the results are profound:

```shell
$ benchstat before.txt after.txt
name          old time/op    new time/op    delta
TreeString-8     111ms ± 8%       4ms ± 4%  -96.01%  (p=0.000 n=20+20)

name          old alloc/op   new alloc/op   delta
TreeString-8     734MB ± 0%       2MB ± 1%  -99.72%  (p=0.000 n=20+20)

name          old allocs/op  new allocs/op  delta
TreeString-8     37.0k ± 0%     28.7k ± 0%  -22.40%  (p=0.000 n=20+20)
```

Fixes #455