### PR TITLE
relax the restriction of delete latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Improvements
+
+- [#483](https://github.com/cosmos/iavl/pull/483) Allow delete latest version.
+
 ## 0.18.0 (March 10, 2022)
 
 ### Breaking Changes

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -566,13 +566,10 @@ func (tree *MutableTree) deleteVersion(version int64) error {
 	if version <= 0 {
 		return errors.New("version must be greater than 0")
 	}
-	if version == tree.version {
-		return errors.Errorf("cannot delete latest saved version (%d)", version)
-	}
 	if !tree.VersionExists(version) {
 		return errors.Wrap(ErrVersionDoesNotExist, "")
 	}
-	if err := tree.ndb.DeleteVersion(version, true); err != nil {
+	if err := tree.ndb.DeleteVersion(version, false); err != nil {
 		return err
 	}
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -281,8 +281,8 @@ func (ndb *nodeDB) DeleteVersionsRange(fromVersion, toVersion int64) error {
 	defer ndb.mtx.Unlock()
 
 	latest := ndb.getLatestVersion()
-	if latest < toVersion {
-		return errors.Errorf("cannot delete latest saved version (%d)", latest)
+	if latest+1 < toVersion {
+		return errors.Errorf("cannot delete future versions [%d..%d)", latest+1, toVersion)
 	}
 
 	predecessor := ndb.getPreviousVersion(fromVersion)


### PR DESCRIPTION
Closes: #482

This is required for the rollback command to work in cosmos-sdk (https://github.com/cosmos/cosmos-sdk/issues/11333#issuecomment-1064672605).
I'm not sure if there are other consequences of this, but my local test with rollback command seems fine using this change.