### PR TITLE
investigate: ristretto cache with memory bounding

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -88,7 +88,7 @@ func runQueriesSlow(b *testing.B, t *iavl.MutableTree, keyLen int) {
 
 	itree, err := t.GetImmutable(version - 1)
 	require.NoError(b, err)
-	isFastCacheEnabled, err := t.IsFastCacheEnabled() // to ensure fast storage is enabled
+	isFastCacheEnabled, err := itree.IsFastCacheEnabled() // to ensure fast storage is enabled
 	require.NoError(b, err)
 	require.False(b, isFastCacheEnabled) // to ensure fast storage is not enabled
 
@@ -108,7 +108,7 @@ func runKnownQueriesSlow(b *testing.B, t *iavl.MutableTree, keys [][]byte) {
 
 	itree, err := t.GetImmutable(version - 1)
 	require.NoError(b, err)
-	isFastCacheEnabled, err := t.IsFastCacheEnabled() // to ensure fast storage is not enabled
+	isFastCacheEnabled, err := itree.IsFastCacheEnabled() // to ensure fast storage is not enabled
 	require.NoError(b, err)
 	require.False(b, isFastCacheEnabled)
 	b.StartTimer()

--- a/go.mod
+++ b/go.mod
@@ -16,11 +16,13 @@ require (
 require (
 	github.com/DataDog/zstd v1.4.1 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgraph-io/badger/v2 v2.2007.2 // indirect
-	github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de // indirect
+	github.com/dgraph-io/ristretto v0.1.0 // indirect
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 // indirect
 	github.com/dustin/go-humanize v1.0.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/btree v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,7 @@ github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/charithe/durationcheck v0.0.9/go.mod h1:SSbRIBVfMjCi/kEB6K65XEA83D6prSM8ap1UCpNKtgg=
 github.com/chavacava/garif v0.0.0-20220316182200-5cad0b5181d4/go.mod h1:W8EnPSQ8Nv4fUjc/v1/8tHFqhuOJXnRub0dTfuAQktU=
@@ -221,6 +222,8 @@ github.com/dgraph-io/badger/v2 v2.2007.2 h1:EjjK0KqwaFMlPin1ajhP943VPENHJdEz1KLI
 github.com/dgraph-io/badger/v2 v2.2007.2/go.mod h1:26P/7fbL4kUZVEVKLAKXkBXKOydDmM2p1e+NhhnBCAE=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de h1:t0UHb5vdojIDUqktM6+xJAfScFBsVpXZmqC9dsgJmeA=
 github.com/dgraph-io/ristretto v0.0.3-0.20200630154024-f66de99634de/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
+github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -322,6 +325,7 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.0.0-20170517235910-f1bb20e5a188/go.mod h1:vXjM/+wXQnTPR4KqTKDgJukSZ6amVRtWMPEjE6sQoK8=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/nodedb.go
+++ b/nodedb.go
@@ -911,13 +911,6 @@ func (ndb *nodeDB) uncacheFastNode(key []byte) {
 // Add a node to the cache and pop the least recently used node if we've
 // reached the cache size limit.
 func (ndb *nodeDB) cacheFastNode(node *FastNode) {
-	// We value the most recent items the most. Therefore, the higher
-	// the earlier the version, the higher the cost.
-	// const weightVersion float64 = 0.7
-	// const weightSize float64 = 0.3
-
-	// cost := int64(weightVersion*float64((ndb.latestVersion-node.versionLastUpdatedAt)) + weightSize*float64(len(node.key)+len(node.value)))
-
 	ndb.fastNodeCache.Set(node.key, node, 0)
 }
 

--- a/options.go
+++ b/options.go
@@ -1,6 +1,10 @@
 package iavl
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+
+	"github.com/dgraph-io/ristretto"
+)
 
 // Statisc about db runtime state
 type Statistics struct {
@@ -69,6 +73,10 @@ type Options struct {
 
 	// When Stat is not nil, statistical logic needs to be executed
 	Stat *Statistics
+
+	NodeCacheConfig *ristretto.Config
+
+	FastNodeCacheConfig *ristretto.Config
 }
 
 // DefaultOptions returns the default options for IAVL.

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -415,25 +415,7 @@ func assertMirror(t *testing.T, tree *MutableTree, mirror map[string]string, ver
 		require.Equal(t, value, string(actual))
 	}
 
-	assertFastNodeCacheIsLive(t, tree, mirror, version)
 	assertFastNodeDiskIsLive(t, tree, mirror, version)
-}
-
-// Checks that fast node cache matches live state.
-func assertFastNodeCacheIsLive(t *testing.T, tree *MutableTree, mirror map[string]string, version int64) {
-	latestVersion, err := tree.ndb.getLatestVersion()
-	require.NoError(t, err)
-	if latestVersion != version {
-		// The fast node cache check should only be done to the latest version
-		return
-	}
-
-	for key, cacheElem := range tree.ndb.fastNodeCache {
-		liveFastNode, ok := mirror[key]
-
-		require.True(t, ok, "cached fast node must be in the live tree")
-		require.Equal(t, liveFastNode, string(cacheElem.Value.(*FastNode).value), "cached fast node's value must be equal to live state value")
-	}
 }
 
 // Checks that fast nodes on disk match live state.


### PR DESCRIPTION
This is a follow-up to: https://github.com/cosmos/iavl/pull/506#discussion_r900462758
with an attempt to bring in a ristretto cache instead of using a custom implementation. This PR documents the progress and findings and should not be merged in its current state.

This PR only swaps the fast node cache to the ristretto cache.
The following is the config:
```
NumCounters: 1e7,     // number of keys to track frequency of (10M).
MaxCost:     1 << 27, // maximum cost of cache (approx 130MB).
BufferItems: 64,      // number of keys per Get buffer. (suggested default value)
```

With the above config, the cache is supposed to be capped at 130 MB.

There were 2 issues with the switch to ristretto:
- some tests started failing for unknown reasons
   * According to [this article](https://dgraph.io/blog/post/introducing-ristretto-high-perf-go-cache/), ristretto is susceptible to key collisions. I suspect that might be the reason why
- degraded performance:
```
name                                                                  old time/op    new time/op    delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16    2.80µs ± 3%    3.29µs ± 6%  +17.32%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    9.62µs ± 5%    9.30µs ± 4%     ~     (p=0.056 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     338ns ± 2%     395ns ± 6%  +16.86%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    14.3µs ± 2%    13.5µs ± 2%   -5.87%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     64.4ms ± 2%    58.3ms ± 2%   -9.54%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      1.21s ±13%     1.15s ±12%     ~     (p=0.095 n=5+5)
Medium/goleveldb-100000-100-16-40/update-16                              180µs ±24%     171µs ±16%     ~     (p=0.310 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              24.5ms ± 5%    22.5ms ± 9%     ~     (p=0.095 n=5+5)

name                                                                  old alloc/op   new alloc/op   delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      790B ± 0%      822B ± 0%   +4.05%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16    1.41kB ± 1%    1.41kB ± 1%     ~     (p=0.460 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                     0.00B         31.00B ± 0%    +Inf%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                    2.02kB ± 1%    2.03kB ± 0%   +0.49%  (p=0.040 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                     29.3MB ± 0%    29.3MB ± 0%   -0.00%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      276MB ± 0%     277MB ± 0%   +0.36%  (p=0.029 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                             51.3kB ± 8%    51.7kB ± 7%     ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                              6.50MB ± 6%    6.50MB ± 5%     ~     (p=1.000 n=5+5)

name                                                                  old allocs/op  new allocs/op  delta
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-fast-16      15.0 ± 0%      16.0 ± 0%   +6.67%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-no-in-tree-guarantee-slow-16      24.0 ± 0%      24.0 ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/query-hits-fast-16                      0.00           1.00 ± 0%    +Inf%  (p=0.008 n=5+5)
Medium/goleveldb-100000-100-16-40/query-hits-slow-16                      35.0 ± 0%      35.0 ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/iteration-fast-16                       523k ± 0%      523k ± 0%     ~     (all equal)
Medium/goleveldb-100000-100-16-40/iteration-slow-16                      4.71M ± 0%     4.71M ± 0%   +0.05%  (p=0.029 n=4+4)
Medium/goleveldb-100000-100-16-40/update-16                                561 ±16%       567 ±15%     ~     (p=1.000 n=5+5)
Medium/goleveldb-100000-100-16-40/block-16                               73.2k ± 4%     72.5k ± 5%     ~     (p=0.690 n=5+5)
```

I suspect that is because ristretto provides thread safety and concurrency guarantees that we might not really need for our use case.

Based on these findings, I don't think we should investigate ristretto further at this time