### PR TITLE
perf: use fast unsafe bytes->string convertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,16 @@
 
 ## Unreleased
 
+### Improvements
+
+- [#525](https://github.com/cosmos/iavl/pull/525) Optimization: use fast unsafe bytes->string convertion.
+
 ## 0.19.0 (July 6, 2022)
 
 ### Breaking Changes
 
 - [\514](https://github.com/cosmos/iavl/pull/514) Downgrade Tendermint to 0.34.x
-- [\500](https://github.com/cosmos/iavl/pull/500) Return errors instead of panicking. 
+- [\500](https://github.com/cosmos/iavl/pull/500) Return errors instead of panicking.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- [#525](https://github.com/cosmos/iavl/pull/525) Optimization: use fast unsafe bytes->string convertion.
+- [#525](https://github.com/cosmos/iavl/pull/525) Optimization: use fast unsafe bytes->string conversion.
 
 ### Bug Fixes
 

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -61,7 +61,8 @@ func New(maxElementCount int) Cache {
 }
 
 func (c *lruCache) Add(node Node) Node {
-	if e, exists := c.dict[ibytes.UnsafeBytesToStr(node.GetKey())]; exists {
+	keyStr := ibytes.UnsafeBytesToStr(node.GetKey())
+	if e, exists := c.dict[keyStr]; exists {
 		c.ll.MoveToFront(e)
 		old := e.Value
 		e.Value = node
@@ -69,11 +70,10 @@ func (c *lruCache) Add(node Node) Node {
 	}
 
 	elem := c.ll.PushFront(node)
-	c.dict[ibytes.UnsafeBytesToStr(node.GetKey())] = elem
+	c.dict[keyStr] = elem
 
 	if c.ll.Len() > c.maxElementCount {
 		oldest := c.ll.Back()
-
 		return c.remove(oldest)
 	}
 	return nil

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -2,6 +2,8 @@ package cache
 
 import (
 	"container/list"
+
+	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 // Node represents a node eligible for caching.
@@ -59,7 +61,7 @@ func New(maxElementCount int) Cache {
 }
 
 func (c *lruCache) Add(node Node) Node {
-	if e, exists := c.dict[string(node.GetKey())]; exists {
+	if e, exists := c.dict[ibytes.UnsafeBytesToStr(node.GetKey())]; exists {
 		c.ll.MoveToFront(e)
 		old := e.Value
 		e.Value = node
@@ -67,7 +69,7 @@ func (c *lruCache) Add(node Node) Node {
 	}
 
 	elem := c.ll.PushFront(node)
-	c.dict[string(node.GetKey())] = elem
+	c.dict[ibytes.UnsafeBytesToStr(node.GetKey())] = elem
 
 	if c.ll.Len() > c.maxElementCount {
 		oldest := c.ll.Back()
@@ -78,7 +80,7 @@ func (c *lruCache) Add(node Node) Node {
 }
 
 func (nc *lruCache) Get(key []byte) Node {
-	if ele, hit := nc.dict[string(key)]; hit {
+	if ele, hit := nc.dict[ibytes.UnsafeBytesToStr(key)]; hit {
 		nc.ll.MoveToFront(ele)
 		return ele.Value.(Node)
 	}
@@ -86,7 +88,7 @@ func (nc *lruCache) Get(key []byte) Node {
 }
 
 func (c *lruCache) Has(key []byte) bool {
-	_, exists := c.dict[string(key)]
+	_, exists := c.dict[ibytes.UnsafeBytesToStr(key)]
 	return exists
 }
 
@@ -95,7 +97,7 @@ func (nc *lruCache) Len() int {
 }
 
 func (c *lruCache) Remove(key []byte) Node {
-	if elem, exists := c.dict[string(key)]; exists {
+	if elem, exists := c.dict[ibytes.UnsafeBytesToStr(key)]; exists {
 		return c.remove(elem)
 	}
 	return nil
@@ -103,6 +105,6 @@ func (c *lruCache) Remove(key []byte) Node {
 
 func (c *lruCache) remove(e *list.Element) Node {
 	removed := c.ll.Remove(e).(Node)
-	delete(c.dict, string(removed.GetKey()))
+	delete(c.dict, ibytes.UnsafeBytesToStr(removed.GetKey()))
 	return removed
 }

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -12,6 +12,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/cosmos/iavl"
+	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 // TODO: make this configurable?
@@ -94,7 +95,7 @@ func PrintDBStats(db dbm.DB) {
 
 	defer itr.Close()
 	for ; itr.Valid(); itr.Next() {
-		key := string(itr.Key()[:1])
+		key := ibytes.UnsafeBytesToStr(itr.Key()[:1])
 		prefix[key]++
 		count++
 	}

--- a/internal/bytes/bytes.go
+++ b/internal/bytes/bytes.go
@@ -35,11 +35,13 @@ func (bz *HexBytes) UnmarshalJSON(data []byte) error {
 	if len(data) < 2 || data[0] != '"' || data[len(data)-1] != '"' {
 		return fmt.Errorf("invalid hex string: %s", data)
 	}
-	bz2, err := hex.DecodeString(string(data[1 : len(data)-1]))
+	data = data[1 : len(data)-1]
+	dest := make([]byte, hex.DecodedLen(len(data)))
+	_, err := hex.Decode(dest, data)
 	if err != nil {
 		return err
 	}
-	*bz = bz2
+	*bz = dest
 	return nil
 }
 

--- a/internal/bytes/string.go
+++ b/internal/bytes/string.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// UnsafeStrToBytes uses unsafe to convert string into byte array. Returned bytes
+// must not be altered after this function is called as it will cause a segmentation fault.
+func UnsafeStrToBytes(s string) []byte {
+	var buf []byte
+	sHdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bufHdr := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
+	bufHdr.Data = sHdr.Data
+	bufHdr.Cap = sHdr.Len
+	bufHdr.Len = sHdr.Len
+	return buf
+}
+
+// UnsafeBytesToStr is meant to make a zero allocation conversion
+// from []byte -> string to speed up operations, it is not meant
+// to be used generally, but for a specific pattern to delete keys
+// from a map.
+func UnsafeBytesToStr(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}

--- a/internal/bytes/string_test.go
+++ b/internal/bytes/string_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+)
+
+func TestStringSuite(t *testing.T) {
+	suite.Run(t, new(StringSuite))
+}
+
+type StringSuite struct{ suite.Suite }
+
+func unsafeConvertStr() []byte {
+	return UnsafeStrToBytes("abc")
+}
+
+func (s *StringSuite) TestUnsafeStrToBytes() {
+	// we convert in other function to trigger GC. We want to check that
+	// the underlying array in []bytes is accessible after GC will finish swapping.
+	for i := 0; i < 5; i++ {
+		b := unsafeConvertStr()
+		runtime.GC()
+		<-time.NewTimer(2 * time.Millisecond).C
+		b2 := append(b, 'd')
+		s.Equal("abc", string(b))
+		s.Equal("abcd", string(b2))
+	}
+}
+
+func unsafeConvertBytes() string {
+	return UnsafeBytesToStr([]byte("abc"))
+}
+
+func (s *StringSuite) TestUnsafeBytesToStr() {
+	// we convert in other function to trigger GC. We want to check that
+	// the underlying array in []bytes is accessible after GC will finish swapping.
+	for i := 0; i < 5; i++ {
+		str := unsafeConvertBytes()
+		runtime.GC()
+		<-time.NewTimer(2 * time.Millisecond).C
+		s.Equal("abc", str)
+	}
+}
+
+func BenchmarkUnsafeStrToBytes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		UnsafeStrToBytes(strconv.Itoa(i))
+	}
+}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -9,11 +9,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/cosmos/iavl/internal/logger"
 	"github.com/pkg/errors"
 	dbm "github.com/tendermint/tm-db"
 
-	ibytes "github.com/cosmos/iavl/internal/bytes"
+	"github.com/cosmos/iavl/internal/logger"
 )
 
 // ErrVersionDoesNotExist is returned if a requested version does not exist.
@@ -147,7 +146,7 @@ func (tree *MutableTree) Get(key []byte) ([]byte, error) {
 		return nil, nil
 	}
 
-	if fastNode, ok := tree.unsavedFastNodeAdditions[ibytes.UnsafeBytesToStr(key)]; ok {
+	if fastNode, ok := tree.unsavedFastNodeAdditions[unsafeToStr(key)]; ok {
 		return fastNode.value, nil
 	}
 
@@ -916,7 +915,7 @@ func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
 }
 
 func (tree *MutableTree) addUnsavedAddition(key []byte, node *FastNode) {
-	skey := ibytes.UnsafeBytesToStr(key)
+	skey := unsafeToStr(key)
 	delete(tree.unsavedFastNodeRemovals, skey)
 	tree.unsavedFastNodeAdditions[skey] = node
 }
@@ -937,7 +936,7 @@ func (tree *MutableTree) saveFastNodeAdditions() error {
 }
 
 func (tree *MutableTree) addUnsavedRemoval(key []byte) {
-	skey := ibytes.UnsafeBytesToStr(key)
+	skey := unsafeToStr(key)
 	delete(tree.unsavedFastNodeAdditions, skey)
 	tree.unsavedFastNodeRemovals[skey] = true
 }
@@ -950,7 +949,7 @@ func (tree *MutableTree) saveFastNodeRemovals() error {
 	sort.Strings(keysToSort)
 
 	for _, key := range keysToSort {
-		if err := tree.ndb.DeleteFastNode(ibytes.UnsafeStrToBytes(key)); err != nil {
+		if err := tree.ndb.DeleteFastNode(unsafeToBz(key)); err != nil {
 			return err
 		}
 	}
@@ -1230,7 +1229,7 @@ func (tree *MutableTree) addOrphans(orphans []*Node) error {
 		if len(node.hash) == 0 {
 			return fmt.Errorf("expected to find node hash, but was empty")
 		}
-		tree.orphans[ibytes.UnsafeBytesToStr(node.hash)] = node.version
+		tree.orphans[unsafeToStr(node.hash)] = node.version
 	}
 	return nil
 }

--- a/tree_dotgraph.go
+++ b/tree_dotgraph.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"text/template"
+
+	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 type graphEdge struct {
@@ -56,12 +58,12 @@ func WriteDOTGraph(w io.Writer, tree *ImmutableTree, paths []PathToLeaf) {
 		}
 		shortHash := graphNode.Hash[:7]
 
-		graphNode.Label = mkLabel(string(node.key), 16, "sans-serif")
+		graphNode.Label = mkLabel(ibytes.UnsafeBytesToStr(node.key), 16, "sans-serif")
 		graphNode.Label += mkLabel(shortHash, 10, "monospace")
 		graphNode.Label += mkLabel(fmt.Sprintf("version=%d", node.version), 10, "monospace")
 
 		if node.value != nil {
-			graphNode.Label += mkLabel(string(node.value), 10, "sans-serif")
+			graphNode.Label += mkLabel(ibytes.UnsafeBytesToStr(node.value), 10, "sans-serif")
 		}
 
 		if node.height == 0 {

--- a/tree_dotgraph.go
+++ b/tree_dotgraph.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"io"
 	"text/template"
-
-	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 type graphEdge struct {
@@ -58,12 +56,12 @@ func WriteDOTGraph(w io.Writer, tree *ImmutableTree, paths []PathToLeaf) {
 		}
 		shortHash := graphNode.Hash[:7]
 
-		graphNode.Label = mkLabel(ibytes.UnsafeBytesToStr(node.key), 16, "sans-serif")
+		graphNode.Label = mkLabel(unsafeToStr(node.key), 16, "sans-serif")
 		graphNode.Label += mkLabel(shortHash, 10, "monospace")
 		graphNode.Label += mkLabel(fmt.Sprintf("version=%d", node.version), 10, "monospace")
 
 		if node.value != nil {
-			graphNode.Label += mkLabel(ibytes.UnsafeBytesToStr(node.value), 10, "sans-serif")
+			graphNode.Label += mkLabel(unsafeToStr(node.value), 10, "sans-serif")
 		}
 
 		if node.height == 0 {

--- a/unsafe.go
+++ b/unsafe.go
@@ -1,0 +1,8 @@
+package iavl
+
+import ibytes "github.com/cosmos/iavl/internal/bytes"
+
+var (
+	unsafeToStr = ibytes.UnsafeBytesToStr
+	unsafeToBz  = ibytes.UnsafeStrToBytes
+)

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 
 	dbm "github.com/tendermint/tm-db"
+
+	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 var (
@@ -18,29 +20,19 @@ var (
 // it iterates over the latest state via fast nodes,
 // taking advantage of keys being located in sequence in the underlying database.
 type UnsavedFastIterator struct {
-	start, end []byte
-
-	valid bool
-
-	ascending bool
-
-	err error
-
-	ndb *nodeDB
-
-	unsavedFastNodeAdditions map[string]*FastNode
-
-	unsavedFastNodeRemovals map[string]interface{}
-
-	unsavedFastNodesToSort []string
-
-	nextKey []byte
-
-	nextVal []byte
-
-	nextUnsavedNodeIdx int
-
+	start, end   []byte
+	valid        bool
+	ascending    bool
+	err          error
+	ndb          *nodeDB
+	nextKey      []byte
+	nextVal      []byte
 	fastIterator dbm.Iterator
+
+	nextUnsavedNodeIdx       int
+	unsavedFastNodeAdditions map[string]*FastNode
+	unsavedFastNodeRemovals  map[string]interface{}
+	unsavedFastNodesToSort   []string
 }
 
 var _ dbm.Iterator = (*UnsavedFastIterator)(nil)
@@ -71,7 +63,7 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 			continue
 		}
 
-		iter.unsavedFastNodesToSort = append(iter.unsavedFastNodesToSort, string(fastNode.key))
+		iter.unsavedFastNodesToSort = append(iter.unsavedFastNodesToSort, ibytes.UnsafeBytesToStr(fastNode.key))
 	}
 
 	sort.Slice(iter.unsavedFastNodesToSort, func(i, j int) bool {
@@ -142,8 +134,8 @@ func (iter *UnsavedFastIterator) Next() {
 		return
 	}
 
+	diskKeyStr := ibytes.UnsafeBytesToStr(iter.fastIterator.Key())
 	if iter.fastIterator.Valid() && iter.nextUnsavedNodeIdx < len(iter.unsavedFastNodesToSort) {
-		diskKeyStr := string(iter.fastIterator.Key())
 
 		if iter.unsavedFastNodeRemovals[diskKeyStr] != nil {
 			// If next fast node from disk is to be removed, skip it.
@@ -186,7 +178,7 @@ func (iter *UnsavedFastIterator) Next() {
 
 	// if only nodes on disk are left, we return them
 	if iter.fastIterator.Valid() {
-		if iter.unsavedFastNodeRemovals[string(iter.fastIterator.Key())] != nil {
+		if iter.unsavedFastNodeRemovals[diskKeyStr] != nil {
 			// If next fast node from disk is to be removed, skip it.
 			iter.fastIterator.Next()
 			iter.Next()

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -6,8 +6,6 @@ import (
 	"sort"
 
 	dbm "github.com/tendermint/tm-db"
-
-	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 var (
@@ -63,7 +61,7 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 			continue
 		}
 
-		iter.unsavedFastNodesToSort = append(iter.unsavedFastNodesToSort, ibytes.UnsafeBytesToStr(fastNode.key))
+		iter.unsavedFastNodesToSort = append(iter.unsavedFastNodesToSort, unsafeToStr(fastNode.key))
 	}
 
 	sort.Slice(iter.unsavedFastNodesToSort, func(i, j int) bool {
@@ -134,7 +132,7 @@ func (iter *UnsavedFastIterator) Next() {
 		return
 	}
 
-	diskKeyStr := ibytes.UnsafeBytesToStr(iter.fastIterator.Key())
+	diskKeyStr := unsafeToStr(iter.fastIterator.Key())
 	if iter.fastIterator.Valid() && iter.nextUnsavedNodeIdx < len(iter.unsavedFastNodesToSort) {
 
 		if iter.unsavedFastNodeRemovals[diskKeyStr] != nil {


### PR DESCRIPTION
Avoid unnecessary allocation by using fast unsafe bytes -> string conversion

Notes:
+ I didn't add conversions to the tests - I'm planning other PR there to cleanup key / values repetitions.