### PR TITLE
make: don't run tests on benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,21 +46,20 @@ lint:
 # bench is the basic tests that shouldn't crash an aws instance
 bench:
 	cd benchmarks && \
-		go test $(LDFLAGS) -bench=RandomBytes . && \
-		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -bench=Small . && \
-		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -bench=Medium . && \
-		go test $(LDFLAGS) -bench=BenchmarkMemKeySizes .
+		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -run=NOTEST -bench=Small . && \
+		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -run=NOTEST -bench=Medium . && \
+		go test $(LDFLAGS) -run=NOTEST -bench=RandomBytes .
 .PHONY: bench
 
 # fullbench is extra tests needing lots of memory and to run locally
 fullbench:
 	cd benchmarks && \
-		go test $(LDFLAGS) -bench=RandomBytes . && \
-		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -bench=Small . && \
-		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -bench=Medium . && \
-		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -timeout=30m -bench=Large . && \
-		go test $(LDFLAGS) -bench=Mem . && \
-		go test $(LDFLAGS) -timeout=60m -bench=LevelDB .
+		go test $(LDFLAGS) -run=NOTEST -bench=RandomBytes . && \
+		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -run=NOTEST -bench=Small . && \
+		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -run=NOTEST -bench=Medium . && \
+		go test $(LDFLAGS) -tags cleveldb,rocksdb,boltdb,badgerdb -run=NOTEST -timeout=30m -bench=Large . && \
+		go test $(LDFLAGS) -run=NOTEST -bench=Mem . && \
+		go test $(LDFLAGS) -run=NOTEST -timeout=60m -bench=LevelDB .
 .PHONY: fullbench
 
 # note that this just profiles the in-memory version, not persistence


### PR DESCRIPTION
In benchmarks we were running tests, which should be run separately
Moreover:
+ cleaned up makefile to remove not existing benchmark expressions