### PR TITLE
golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,12 +10,11 @@ linters:
     - deadcode
     - depguard
     - dogsled
-    # - errcheck
+    - errcheck
     - exportloopref
     - goconst
     - gocritic
-    - gofmt
-    - goimports
+    - gofumpt
     - gosec
     - gosimple
     - govet
@@ -32,7 +31,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    # - wsl
 
 issues:
   exclude-rules:


### PR DESCRIPTION
* removes gofmt and goimports in favor of gofumpt
* enables errcheck