### PR TITLE
benchmarks: only log the spammy iterations completed message if -v is set

### DIFF
--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -152,7 +152,7 @@ func iterate(b *testing.B, itr db.Iterator, expectedSize int) {
 	b.StopTimer()
 	if g, w := len(keyValuePairs), expectedSize; g != w {
 		b.Errorf("iteration count mismatch: got=%d, want=%d", g, w)
-	} else {
+	} else if testing.Verbose() {
 		b.Logf("completed %d iterations", len(keyValuePairs))
 	}
 }


### PR DESCRIPTION
Only log to error log iff the -v flag is set, this prevents spammy logs and burning unnecessary time and logs.

Fixes #552