### PR TITLE
feat: add iterator concurrency tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,5 +26,5 @@ jobs:
       - name: test & coverage report creation
         run: |
           go test ./... -mod=readonly -timeout 5m -short -race -coverprofile=coverage.txt -covermode=atomic
-          go test ./... -mod=readonly -timeout 5m
-          GOARCH=386 go test ./... -mod=readonly -timeout 5m
+          go test ./... -mod=readonly -timeout 8m
+          GOARCH=386 go test ./... -mod=readonly -timeout 8m

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -39,6 +39,9 @@ func setupMutableTree(t *testing.T, skipFastStorageUpgrade bool) *MutableTree {
 
 // TestIterateConcurrency throws "fatal error: concurrent map writes" when fast node is enabled
 func TestIterateConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	tree := setupMutableTree(t, true)
 
 	for i := 0; i < 100; i++ {
@@ -56,6 +59,9 @@ func TestIterateConcurrency(t *testing.T) {
 // TestConcurrency throws "fatal error: concurrent map iteration and map write" and
 // also sometimes "fatal error: concurrent map writes" when fast node is enabled
 func TestIteratorConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	tree := setupMutableTree(t, true)
 
 	tree.LoadVersion(0)
@@ -74,6 +80,9 @@ func TestIteratorConcurrency(t *testing.T) {
 
 // TestNewIteratorConcurrency throws "fatal error: concurrent map writes" when fast node is enabled
 func TestNewIteratorConcurrency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
 	tree := setupMutableTree(t, true)
 	for i := 0; i < 100; i++ {
 		go func(i int) {

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -46,7 +46,7 @@ func TestIterateConcurrency(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		go func(i int) {
-			for j := 0; j < 1000000; j++ {
+			for j := 0; j < 100000; j++ {
 				tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), rand.Bytes(1))
 			}
 		}(i)
@@ -86,7 +86,7 @@ func TestNewIteratorConcurrency(t *testing.T) {
 	tree := setupMutableTree(t, true)
 	for i := 0; i < 100; i++ {
 		go func(i int) {
-			for j := 0; j < 1000000; j++ {
+			for j := 0; j < 100000; j++ {
 				tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), rand.Bytes(1))
 			}
 		}(i)

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -37,16 +37,16 @@ func setupMutableTree(t *testing.T, skipFastStorageUpgrade bool) *MutableTree {
 	return tree
 }
 
-// TestIterateConcurrency throws "fatal error: concurrent map writes" when fast node is enable
+// TestIterateConcurrency throws "fatal error: concurrent map writes" when fast node is enabled
 func TestIterateConcurrency(t *testing.T) {
 	tree := setupMutableTree(t, true)
 
 	for i := 0; i < 100; i++ {
-		go func() {
+		go func(i int) {
 			for j := 0; j < 1000000; j++ {
 				tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), rand.Bytes(1))
 			}
-		}()
+		}(i)
 		tree.Iterate(func(key []byte, value []byte) bool {
 			return false
 		})
@@ -54,33 +54,33 @@ func TestIterateConcurrency(t *testing.T) {
 }
 
 // TestConcurrency throws "fatal error: concurrent map iteration and map write" and
-// also sometimes "fatal error: concurrent map writes" when fast node is enable
+// also sometimes "fatal error: concurrent map writes" when fast node is enabled
 func TestIteratorConcurrency(t *testing.T) {
 	tree := setupMutableTree(t, true)
 
 	tree.LoadVersion(0)
 	// So much slower
 	for i := 0; i < 100; i++ {
-		go func() {
+		go func(i int) {
 			for j := 0; j < 100000; j++ {
 				tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), rand.Bytes(1))
 			}
-		}()
+		}(i)
 		itr, _ := tree.Iterator(nil, nil, true)
 		for ; itr.Valid(); itr.Next() {
 		}
 	}
 }
 
-// TestNewIteratorConcurrency throws "fatal error: concurrent map writes" when fast node is enable
+// TestNewIteratorConcurrency throws "fatal error: concurrent map writes" when fast node is enabled
 func TestNewIteratorConcurrency(t *testing.T) {
 	tree := setupMutableTree(t, true)
 	for i := 0; i < 100; i++ {
-		go func() {
+		go func(i int) {
 			for j := 0; j < 1000000; j++ {
 				tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), rand.Bytes(1))
 			}
-		}()
+		}(i)
 		it := NewIterator(nil, nil, true, tree.ImmutableTree)
 		for ; it.Valid(); it.Next() {
 		}


### PR DESCRIPTION
Adding 3 simple tests that will fail if any new change makes the current situation with concurrency worse. These 3 always fail if the fast node is enabled (can be passed to `setupMutableTree`).