### PR TITLE
refactor: disable remaining fast node logic in mutable tree

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -194,13 +194,11 @@ func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stoppe
 		return tree.ImmutableTree.Iterate(fn)
 	}
 
-	if !tree.skipFastStorageUpgrade {
-		itr := NewUnsavedFastIterator(nil, nil, true, tree.ndb, tree.unsavedFastNodeAdditions, tree.unsavedFastNodeRemovals)
-		defer itr.Close()
-		for ; itr.Valid(); itr.Next() {
-			if fn(itr.Key(), itr.Value()) {
-				return true, nil
-			}
+	itr := NewUnsavedFastIterator(nil, nil, true, tree.ndb, tree.unsavedFastNodeAdditions, tree.unsavedFastNodeRemovals)
+	defer itr.Close()
+	for ; itr.Valid(); itr.Next() {
+		if fn(itr.Key(), itr.Value()) {
+			return true, nil
 		}
 	}
 	return false, nil


### PR DESCRIPTION
Skip fast node removals when fast node is disabled to avoid any possibility of those removals being read, leading to inconsistent state between nodes that have fast nodes and the nodes that do not.