### PR TITLE
Revert "feat: Add `skipFastStorageUpgrade` to `MutableTree` to contro…

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -470,7 +470,7 @@ func TestPersistence(t *testing.T) {
 	}
 
 	// Construct some tree and save it
-	t1, err := NewMutableTree(db, 0, false)
+	t1, err := NewMutableTree(db, 0)
 	require.NoError(t, err)
 	for key, value := range records {
 		t1.Set([]byte(key), []byte(value))
@@ -478,7 +478,7 @@ func TestPersistence(t *testing.T) {
 	t1.SaveVersion()
 
 	// Load a tree
-	t2, err := NewMutableTree(db, 0, false)
+	t2, err := NewMutableTree(db, 0)
 	require.NoError(t, err)
 	t2.Load()
 	for key, value := range records {
@@ -528,7 +528,7 @@ func TestProof(t *testing.T) {
 
 func TestTreeProof(t *testing.T) {
 	db := db.NewMemDB()
-	tree, err := NewMutableTree(db, 100, false)
+	tree, err := NewMutableTree(db, 100)
 	require.NoError(t, err)
 	hash, err := tree.Hash()
 	require.NoError(t, err)

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -25,7 +25,7 @@ func randBytes(length int) []byte {
 }
 
 func prepareTree(b *testing.B, db db.DB, size, keyLen, dataLen int) (*iavl.MutableTree, [][]byte) {
-	t, err := iavl.NewMutableTreeWithOpts(db, size, nil, false)
+	t, err := iavl.NewMutableTreeWithOpts(db, size, nil)
 	require.NoError(b, err)
 	keys := make([][]byte, size)
 

--- a/benchmarks/cosmos-exim/main.go
+++ b/benchmarks/cosmos-exim/main.go
@@ -90,7 +90,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 	if err != nil {
 		return 0, nil, err
 	}
-	tree, err := iavl.NewMutableTree(tmdb.NewPrefixDB(ldb, []byte("s/k:main/")), 0, false)
+	tree, err := iavl.NewMutableTree(tmdb.NewPrefixDB(ldb, []byte("s/k:main/")), 0)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -105,7 +105,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 	totalStats := Stats{}
 	for _, name := range stores {
 		db := tmdb.NewPrefixDB(ldb, []byte("s/k:"+name+"/"))
-		tree, err := iavl.NewMutableTree(db, 0, false)
+		tree, err := iavl.NewMutableTree(db, 0)
 		if err != nil {
 			return 0, nil, err
 		}
@@ -170,7 +170,7 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 		if err != nil {
 			return err
 		}
-		newTree, err := iavl.NewMutableTree(newDB, 0, false)
+		newTree, err := iavl.NewMutableTree(newDB, 0)
 		if err != nil {
 			return err
 		}

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -126,7 +126,7 @@ func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error)
 		db = dbm.NewPrefixDB(db, prefix)
 	}
 
-	tree, err := iavl.NewMutableTree(db, DefaultCacheSize, false)
+	tree, err := iavl.NewMutableTree(db, DefaultCacheSize)
 	if err != nil {
 		return nil, err
 	}

--- a/export_test.go
+++ b/export_test.go
@@ -14,7 +14,7 @@ import (
 // setupExportTreeBasic sets up a basic tree with a handful of
 // create/update/delete operations over a few versions.
 func setupExportTreeBasic(t require.TestingT) *ImmutableTree {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	tree.Set([]byte("x"), []byte{255})
@@ -59,7 +59,7 @@ func setupExportTreeRandom(t *testing.T) *ImmutableTree {
 	)
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	var version int64
@@ -119,7 +119,7 @@ func setupExportTreeSized(t require.TestingT, treeSize int) *ImmutableTree {
 	)
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	for i := 0; i < treeSize; i++ {
@@ -176,7 +176,7 @@ func TestExporter(t *testing.T) {
 
 func TestExporter_Import(t *testing.T) {
 	testcases := map[string]*ImmutableTree{
-		"empty tree": NewImmutableTree(db.NewMemDB(), 0, false),
+		"empty tree": NewImmutableTree(db.NewMemDB(), 0),
 		"basic tree": setupExportTreeBasic(t),
 	}
 	if !testing.Short() {
@@ -192,7 +192,7 @@ func TestExporter_Import(t *testing.T) {
 			exporter := tree.Export()
 			defer exporter.Close()
 
-			newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+			newTree, err := NewMutableTree(db.NewMemDB(), 0)
 			require.NoError(t, err)
 			importer, err := newTree.Import(tree.Version())
 			require.NoError(t, err)
@@ -256,7 +256,7 @@ func TestExporter_Close(t *testing.T) {
 }
 
 func TestExporter_DeleteVersionErrors(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	tree.Set([]byte("a"), []byte{1})

--- a/import_test.go
+++ b/import_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func ExampleImporter() {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	if err != nil {
 		// handle err
 	}
@@ -41,7 +41,7 @@ func ExampleImporter() {
 		exported = append(exported, node)
 	}
 
-	newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	newTree, err := NewMutableTree(db.NewMemDB(), 0)
 	if err != nil {
 		// handle err
 	}
@@ -63,14 +63,14 @@ func ExampleImporter() {
 }
 
 func TestImporter_NegativeVersion(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	_, err = tree.Import(-1)
 	require.Error(t, err)
 }
 
 func TestImporter_NotEmpty(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	tree.Set([]byte("a"), []byte{1})
 	_, _, err = tree.SaveVersion()
@@ -83,13 +83,13 @@ func TestImporter_NotEmpty(t *testing.T) {
 func TestImporter_NotEmptyDatabase(t *testing.T) {
 	db := db.NewMemDB()
 
-	tree, err := NewMutableTree(db, 0, false)
+	tree, err := NewMutableTree(db, 0)
 	require.NoError(t, err)
 	tree.Set([]byte("a"), []byte{1})
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
-	tree, err = NewMutableTree(db, 0, false)
+	tree, err = NewMutableTree(db, 0)
 	require.NoError(t, err)
 	_, err = tree.Load()
 	require.NoError(t, err)
@@ -99,7 +99,7 @@ func TestImporter_NotEmptyDatabase(t *testing.T) {
 }
 
 func TestImporter_NotEmptyUnsaved(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	tree.Set([]byte("a"), []byte{1})
 
@@ -126,7 +126,7 @@ func TestImporter_Add(t *testing.T) {
 	for desc, tc := range testcases {
 		tc := tc // appease scopelint
 		t.Run(desc, func(t *testing.T) {
-			tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+			tree, err := NewMutableTree(db.NewMemDB(), 0)
 			require.NoError(t, err)
 			importer, err := tree.Import(1)
 			require.NoError(t, err)
@@ -143,7 +143,7 @@ func TestImporter_Add(t *testing.T) {
 }
 
 func TestImporter_Add_Closed(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -155,7 +155,7 @@ func TestImporter_Add_Closed(t *testing.T) {
 }
 
 func TestImporter_Close(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -172,7 +172,7 @@ func TestImporter_Close(t *testing.T) {
 }
 
 func TestImporter_Commit(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -188,7 +188,7 @@ func TestImporter_Commit(t *testing.T) {
 }
 
 func TestImporter_Commit_Closed(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	importer, err := tree.Import(1)
 	require.NoError(t, err)
@@ -203,7 +203,7 @@ func TestImporter_Commit_Closed(t *testing.T) {
 }
 
 func TestImporter_Commit_Empty(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 	importer, err := tree.Import(3)
 	require.NoError(t, err)
@@ -232,7 +232,7 @@ func BenchmarkImport(b *testing.B) {
 	b.StartTimer()
 
 	for n := 0; n < b.N; n++ {
-		newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
+		newTree, err := NewMutableTree(db.NewMemDB(), 0)
 		require.NoError(b, err)
 		importer, err := newTree.Import(tree.Version())
 		require.NoError(b, err)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -56,7 +56,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	}
 
 	t.Run("Nil additions given", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, nil, tree.unsavedFastNodeRemovals)
 		performTest(t, itr)
@@ -64,7 +64,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	})
 
 	t.Run("Nil removals given", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, tree.unsavedFastNodeAdditions, nil)
 		performTest(t, itr)
@@ -78,7 +78,7 @@ func TestUnsavedFastIterator_NewIterator_NilAdditions_Failure(t *testing.T) {
 	})
 
 	t.Run("Additions and removals are nil", func(t *testing.T) {
-		tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+		tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 		require.NoError(t, err)
 		itr := NewUnsavedFastIterator(start, end, ascending, tree.ndb, nil, nil)
 		performTest(t, itr)
@@ -248,7 +248,7 @@ func iteratorSuccessTest(t *testing.T, config *iteratorTestConfig) {
 }
 
 func setupIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	mirror := setupMirrorForIterator(t, config, tree)
@@ -265,7 +265,7 @@ func setupIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Itera
 }
 
 func setupFastIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	mirror := setupMirrorForIterator(t, config, tree)
@@ -277,7 +277,7 @@ func setupFastIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.I
 }
 
 func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Iterator, [][]string) {
-	tree, err := NewMutableTree(dbm.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(dbm.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	// For unsaved fast iterator, we would like to test the state where

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -34,7 +34,7 @@ var (
 
 func setupMutableTree(t *testing.T, skipFastStorageUpgrade bool) *MutableTree {
 	memDB := db.NewMemDB()
-	tree, err := NewMutableTree(memDB, 0, skipFastStorageUpgrade)
+	tree, err := NewMutableTree(memDB, 0)
 	require.NoError(t, err)
 	return tree
 }
@@ -257,7 +257,7 @@ func TestMutableTree_LoadVersion_Empty(t *testing.T) {
 
 func TestMutableTree_LazyLoadVersion_Empty(t *testing.T) {
 	memDB := db.NewMemDB()
-	tree, err := NewMutableTree(memDB, 0, false)
+	tree, err := NewMutableTree(memDB, 0)
 	require.NoError(t, err)
 
 	version, err := tree.LazyLoadVersion(0)
@@ -276,7 +276,7 @@ func TestMutableTree_DeleteVersionsRange(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0)
 	require.NoError(err)
 	const maxLength = 100
 	const fromLength = 10
@@ -292,7 +292,7 @@ func TestMutableTree_DeleteVersionsRange(t *testing.T) {
 		require.NoError(err, "SaveVersion should not fail")
 	}
 
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0)
 	require.NoError(err)
 	targetVersion, err := tree.LoadVersion(int64(maxLength))
 	require.NoError(err)
@@ -355,7 +355,7 @@ func TestMutableTree_DeleteVersionsRange(t *testing.T) {
 
 func TestMutableTree_InitialVersion(t *testing.T) {
 	memDB := db.NewMemDB()
-	tree, err := NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9}, false)
+	tree, err := NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9})
 	require.NoError(t, err)
 
 	tree.Set([]byte("a"), []byte{0x01})
@@ -369,20 +369,20 @@ func TestMutableTree_InitialVersion(t *testing.T) {
 	assert.EqualValues(t, 10, version)
 
 	// Reloading the tree with the same initial version is fine
-	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9}, false)
+	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9})
 	require.NoError(t, err)
 	version, err = tree.Load()
 	require.NoError(t, err)
 	assert.EqualValues(t, 10, version)
 
 	// Reloading the tree with an initial version beyond the lowest should error
-	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 10}, false)
+	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 10})
 	require.NoError(t, err)
 	_, err = tree.Load()
 	require.Error(t, err)
 
 	// Reloading the tree with a lower initial version is fine, and new versions can be produced
-	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 3}, false)
+	tree, err = NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 3})
 	require.NoError(t, err)
 	version, err = tree.Load()
 	require.NoError(t, err)
@@ -407,7 +407,7 @@ func TestMutableTree_SetInitialVersion(t *testing.T) {
 func BenchmarkMutableTree_Set(b *testing.B) {
 	db, err := db.NewDB("test", db.MemDBBackend, "")
 	require.NoError(b, err)
-	t, err := NewMutableTree(db, 100000, false)
+	t, err := NewMutableTree(db, 100000)
 	require.NoError(b, err)
 	for i := 0; i < 1000000; i++ {
 		t.Set(iavlrand.RandBytes(10), []byte{})
@@ -424,7 +424,7 @@ func BenchmarkMutableTree_Set(b *testing.B) {
 
 func prepareTree(t *testing.T) *MutableTree {
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 1000, false)
+	tree, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 	for i := 0; i < 100; i++ {
 		tree.Set([]byte{byte(i)}, []byte("a"))
@@ -438,7 +438,7 @@ func prepareTree(t *testing.T) *MutableTree {
 	_, ver, err = tree.SaveVersion()
 	require.True(t, ver == 2)
 	require.NoError(t, err)
-	newTree, err := NewMutableTree(mdb, 1000, false)
+	newTree, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 
 	return newTree
@@ -494,18 +494,18 @@ func TestMutableTree_DeleteVersion(t *testing.T) {
 
 func TestMutableTree_LazyLoadVersionWithEmptyTree(t *testing.T) {
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 1000, false)
+	tree, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 	_, v1, err := tree.SaveVersion()
 	require.NoError(t, err)
 
-	newTree1, err := NewMutableTree(mdb, 1000, false)
+	newTree1, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 	v2, err := newTree1.LazyLoadVersion(1)
 	require.NoError(t, err)
 	require.True(t, v1 == v2)
 
-	newTree2, err := NewMutableTree(mdb, 1000, false)
+	newTree2, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 	v2, err = newTree1.LoadVersion(1)
 	require.NoError(t, err)
@@ -516,7 +516,7 @@ func TestMutableTree_LazyLoadVersionWithEmptyTree(t *testing.T) {
 
 func TestMutableTree_SetSimple(t *testing.T) {
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0)
 	require.NoError(t, err)
 
 	const testKey1 = "a"
@@ -687,7 +687,7 @@ func TestMutableTree_SetRemoveSet(t *testing.T) {
 
 func TestMutableTree_FastNodeIntegration(t *testing.T) {
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 1000, false)
+	tree, err := NewMutableTree(mdb, 1000)
 	require.NoError(t, err)
 
 	const key1 = "a"
@@ -752,7 +752,7 @@ func TestMutableTree_FastNodeIntegration(t *testing.T) {
 	require.Equal(t, len(unsavedNodeRemovals), 0)
 
 	// Load
-	t2, err := NewMutableTree(mdb, 0, false)
+	t2, err := NewMutableTree(mdb, 0)
 	require.NoError(t, err)
 
 	_, err = t2.Load()
@@ -821,7 +821,7 @@ func TestIterator_MutableTree_Invalid(t *testing.T) {
 func TestUpgradeStorageToFast_LatestVersion_Success(t *testing.T) {
 	// Setup
 	db := db.NewMemDB()
-	tree, err := NewMutableTree(db, 1000, false)
+	tree, err := NewMutableTree(db, 1000)
 	require.NoError(t, err)
 
 	// Default version when storage key does not exist in the db
@@ -852,7 +852,7 @@ func TestUpgradeStorageToFast_LatestVersion_Success(t *testing.T) {
 func TestUpgradeStorageToFast_AlreadyUpgraded_Success(t *testing.T) {
 	// Setup
 	db := db.NewMemDB()
-	tree, err := NewMutableTree(db, 1000, false)
+	tree, err := NewMutableTree(db, 1000)
 	require.NoError(t, err)
 
 	// Default version when storage key does not exist in the db
@@ -903,7 +903,7 @@ func TestUpgradeStorageToFast_DbErrorConstructor_Failure(t *testing.T) {
 	dbMock.EXPECT().NewBatch().Return(nil).Times(1)
 	dbMock.EXPECT().ReverseIterator(gomock.Any(), gomock.Any()).Return(rIterMock, nil).Times(1)
 
-	tree, err := NewMutableTree(dbMock, 0, false)
+	tree, err := NewMutableTree(dbMock, 0)
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
@@ -938,7 +938,7 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 
 	batchMock.EXPECT().Set(gomock.Any(), gomock.Any()).Return(expectedError).Times(1)
 
-	tree, err := NewMutableTree(dbMock, 0, false)
+	tree, err := NewMutableTree(dbMock, 0)
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
@@ -979,7 +979,7 @@ func TestFastStorageReUpgradeProtection_NoForceUpgrade_Success(t *testing.T) {
 	dbMock.EXPECT().NewBatch().Return(batchMock).Times(1)
 	dbMock.EXPECT().ReverseIterator(gomock.Any(), gomock.Any()).Return(rIterMock, nil).Times(1) // called to get latest version
 
-	tree, err := NewMutableTree(dbMock, 0, false)
+	tree, err := NewMutableTree(dbMock, 0)
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
@@ -1072,7 +1072,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	iterMock.EXPECT().Valid().Return(false).Times(1)
 	iterMock.EXPECT().Close().Return(nil).Times(1)
 
-	tree, err := NewMutableTree(dbMock, 0, false)
+	tree, err := NewMutableTree(dbMock, 0)
 	require.Nil(t, err)
 	require.NotNil(t, tree)
 
@@ -1103,7 +1103,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 
 func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testing.T) {
 	// Setup
-	tree, mirror := setupTreeAndMirror(t, 100, false)
+	tree, mirror := setupTreeAndMirrorForUpgrade(t, 100)
 
 	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
 	require.NoError(t, err)
@@ -1123,7 +1123,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 	require.False(t, isUpgradeable)
 	require.NoError(t, err)
 
-	sut, _ := NewMutableTree(tree.ndb.db, 1000, false)
+	sut, _ := NewMutableTree(tree.ndb.db, 1000)
 
 	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
 	require.NoError(t, err)
@@ -1170,7 +1170,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testi
 
 func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T) {
 	// Setup
-	tree, mirror := setupTreeAndMirror(t, 100, false)
+	tree, mirror := setupTreeAndMirrorForUpgrade(t, 100)
 
 	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
 	require.NoError(t, err)
@@ -1190,7 +1190,7 @@ func TestUpgradeStorageToFast_Integration_Upgraded_GetFast_Success(t *testing.T)
 	require.False(t, isUpgradeable)
 	require.NoError(t, err)
 
-	sut, _ := NewMutableTree(tree.ndb.db, 1000, false)
+	sut, _ := NewMutableTree(tree.ndb.db, 1000)
 
 	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
 	require.NoError(t, err)
@@ -1251,7 +1251,7 @@ func TestUpgradeStorageToFast_Success(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tree, mirror := setupTreeAndMirror(t, tt.fields.nodeCount, false)
+		tree, mirror := setupTreeAndMirrorForUpgrade(t, tt.fields.nodeCount)
 		enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 		require.Nil(t, err)
 		require.True(t, enabled)
@@ -1308,7 +1308,7 @@ func TestUpgradeStorageToFast_Delete_Stale_Success(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tree, mirror := setupTreeAndMirror(t, tt.fields.nodeCount, false)
+		tree, mirror := setupTreeAndMirrorForUpgrade(t, tt.fields.nodeCount)
 		addStaleKey(tree.ndb, tt.fields.staleCount)
 		enabled, err := tree.enableFastStorageAndCommitIfNotEnabled()
 		require.Nil(t, err)
@@ -1326,10 +1326,10 @@ func TestUpgradeStorageToFast_Delete_Stale_Success(t *testing.T) {
 	}
 }
 
-func setupTreeAndMirror(t *testing.T, numEntries int, skipFastStorageUpgrade bool) (*MutableTree, [][]string) {
+func setupTreeAndMirrorForUpgrade(t *testing.T, numEntries int) (*MutableTree, [][]string) {
 	db := db.NewMemDB()
 
-	tree, _ := NewMutableTree(db, 0, skipFastStorageUpgrade)
+	tree, _ := NewMutableTree(db, 0)
 
 	keyPrefix, valPrefix := "key", "val"
 
@@ -1353,166 +1353,4 @@ func setupTreeAndMirror(t *testing.T, numEntries int, skipFastStorageUpgrade boo
 		return mirror[i][0] < mirror[j][0]
 	})
 	return tree, mirror
-}
-
-func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Get_Success(t *testing.T) {
-	// Setup
-	tree, mirror := setupTreeAndMirror(t, 100, true)
-
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err := tree.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	// Should Not auto enable in save version
-	_, _, err = tree.SaveVersion()
-	require.NoError(t, err)
-
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err = tree.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	sut, _ := NewMutableTree(tree.ndb.db, 1000, true)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err = sut.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	// LazyLoadVersion - should not auto enable fast storage
-	version, err := sut.LazyLoadVersion(1)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	// Load - should not auto enable fast storage
-	version, err = sut.Load()
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	// LoadVersion - should not auto enable fast storage
-	version, err = sut.LoadVersion(1)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	// LoadVersionForOverwriting - should not auto enable fast storage
-	version, err = sut.LoadVersionForOverwriting(1)
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	t.Run("Mutable tree", func(t *testing.T) {
-		for _, kv := range mirror {
-			v, err := sut.Get([]byte(kv[0]))
-			require.NoError(t, err)
-			require.Equal(t, []byte(kv[1]), v)
-		}
-	})
-
-	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
-		require.NoError(t, err)
-
-		for _, kv := range mirror {
-			v, err := immutableTree.Get([]byte(kv[0]))
-			require.NoError(t, err)
-			require.Equal(t, []byte(kv[1]), v)
-		}
-	})
-}
-
-func TestNoFastStorageUpgrade_Integration_SaveVersion_Load_Iterate_Success(t *testing.T) {
-	// Setup
-	tree, mirror := setupTreeAndMirror(t, 100, true)
-
-	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err := tree.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	// Should Not auto enable in save version
-	_, _, err = tree.SaveVersion()
-	require.NoError(t, err)
-
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err = tree.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	sut, _ := NewMutableTree(tree.ndb.db, 1000, true)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-	isUpgradeable, err = sut.IsUpgradeable()
-	require.False(t, isUpgradeable)
-	require.NoError(t, err)
-
-	// Load - should not auto enable fast storage
-	version, err := sut.Load()
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = sut.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	// Load - should not auto enable fast storage
-	version, err = sut.Load()
-	require.NoError(t, err)
-	require.Equal(t, int64(1), version)
-
-	isFastCacheEnabled, err = tree.IsFastCacheEnabled()
-	require.NoError(t, err)
-	require.False(t, isFastCacheEnabled)
-
-	// Test that the mutable tree iterates as expected
-	t.Run("Mutable tree", func(t *testing.T) {
-		i := 0
-		sut.Iterate(func(k, v []byte) bool {
-			require.Equal(t, []byte(mirror[i][0]), k)
-			require.Equal(t, []byte(mirror[i][1]), v)
-			i++
-			return false
-		})
-	})
-
-	// Test that the immutable tree iterates as expected
-	t.Run("Immutable tree", func(t *testing.T) {
-		immutableTree, err := sut.GetImmutable(sut.version)
-		require.NoError(t, err)
-
-		i := 0
-		immutableTree.Iterate(func(k, v []byte) bool {
-			require.Equal(t, []byte(mirror[i][0]), k)
-			require.Equal(t, []byte(mirror[i][1]), v)
-			i++
-			return false
-		})
-	})
 }

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -279,7 +279,7 @@ func makeHashes(b *testing.B, seed int64) [][]byte {
 
 func makeAndPopulateMutableTree(tb testing.TB) *MutableTree {
 	memDB := db.NewMemDB()
-	tree, err := NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9}, false)
+	tree, err := NewMutableTreeWithOpts(memDB, 0, &Options{InitialVersion: 9})
 	require.NoError(tb, err)
 
 	for i := 0; i < 1e4; i++ {

--- a/proof_iavl_test.go
+++ b/proof_iavl_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestProofOp(t *testing.T) {
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil)
 	require.NoError(t, err)
 	keys := []byte{0x0a, 0x11, 0x2e, 0x32, 0x50, 0x72, 0x99, 0xa1, 0xe4, 0xf7} // 10 total.
 	for _, ikey := range keys {

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -205,7 +205,7 @@ func GetNonKey(allkeys [][]byte, loc Where) []byte {
 // BuildTree creates random key/values and stores in tree
 // returns a list of all keys in sorted order
 func BuildTree(size int, cacheSize int) (itree *MutableTree, keys [][]byte, err error) {
-	tree, _ := NewMutableTree(db.NewMemDB(), cacheSize, false)
+	tree, _ := NewMutableTree(db.NewMemDB(), cacheSize)
 
 	// insert lots of info and store the bytes
 	keys = make([][]byte, size)

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -42,7 +42,7 @@ func b2i(bz []byte) int {
 
 // Construct a MutableTree
 func getTestTree(cacheSize int) (*MutableTree, error) {
-	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false)
+	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil)
 }
 
 // Convenience for a new node
@@ -323,7 +323,7 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 
 	b.StopTimer()
 
-	t, err := NewMutableTree(db, 100000, false)
+	t, err := NewMutableTree(db, 100000)
 	require.NoError(b, err)
 
 	value := []byte{}

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -83,7 +83,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		if !(r.Float64() < cacheChance) {
 			cacheSize = 0
 		}
-		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options, false)
+		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options)
 		require.NoError(t, err)
 		version, err = tree.Load()
 		require.NoError(t, err)

--- a/tree_test.go
+++ b/tree_test.go
@@ -53,7 +53,7 @@ func TestVersionedRandomTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100)
 	require.NoError(err)
 	versions := 50
 	keysPerVersion := 30
@@ -135,7 +135,7 @@ func TestTreeHash(t *testing.T) {
 	require.Len(t, expectHashes, versions, "must have expected hashes for all versions")
 
 	r := rand.New(rand.NewSource(randSeed))
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	keys := make([][]byte, 0, versionOps)
@@ -186,7 +186,7 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100)
 	require.NoError(err)
 	singleVersionTree, err := getTestTree(0)
 	require.NoError(err)
@@ -236,7 +236,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100)
 	require.NoError(err)
 	singleVersionTree, err := getTestTree(0)
 	require.NoError(err)
@@ -331,7 +331,7 @@ func TestVersionedEmptyTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(err)
 
 	hash, v, err := tree.SaveVersion()
@@ -370,7 +370,7 @@ func TestVersionedEmptyTree(t *testing.T) {
 
 	// Now reload the tree.
 
-	tree, err = NewMutableTree(d, 0, false)
+	tree, err = NewMutableTree(d, 0)
 	require.NoError(err)
 	tree.Load()
 
@@ -389,7 +389,7 @@ func TestVersionedTree(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(err)
 
 	// We start with empty database.
@@ -440,7 +440,7 @@ func TestVersionedTree(t *testing.T) {
 
 	// Recreate a new tree and load it, to make sure it works in this
 	// scenario.
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -494,7 +494,7 @@ func TestVersionedTree(t *testing.T) {
 	require.EqualValues(hash3, hash4)
 	require.NotNil(hash4)
 
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -609,7 +609,7 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(t, err)
 
 	tree.Set([]byte("key0"), []byte("val0"))
@@ -710,7 +710,7 @@ func TestVersionedTreeSpecialCase(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(err)
 
 	tree.Set([]byte("key1"), []byte("val0"))
@@ -735,7 +735,7 @@ func TestVersionedTreeSpecialCase2(t *testing.T) {
 	require := require.New(t)
 
 	d := db.NewMemDB()
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100)
 	require.NoError(err)
 
 	tree.Set([]byte("key1"), []byte("val0"))
@@ -749,7 +749,7 @@ func TestVersionedTreeSpecialCase2(t *testing.T) {
 	tree.Set([]byte("key2"), []byte("val2"))
 	tree.SaveVersion()
 
-	tree, err = NewMutableTree(d, 100, false)
+	tree, err = NewMutableTree(d, 100)
 	require.NoError(err)
 	_, err = tree.Load()
 	require.NoError(err)
@@ -795,7 +795,7 @@ func TestVersionedTreeSpecialCase3(t *testing.T) {
 func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	require := require.New(t)
 	d := db.NewMemDB()
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(err)
 
 	// Loading with an empty root is a no-op.
@@ -821,7 +821,7 @@ func TestVersionedTreeSaveAndLoad(t *testing.T) {
 	require.Equal(int64(6), tree.Version())
 
 	// Reload the tree, to test that roots and orphans are properly loaded.
-	ntree, err := NewMutableTree(d, 0, false)
+	ntree, err := NewMutableTree(d, 0)
 	require.NoError(err)
 	ntree.Load()
 
@@ -883,7 +883,7 @@ func TestVersionedCheckpoints(t *testing.T) {
 	d, closeDB := getTestDB()
 	defer closeDB()
 
-	tree, err := NewMutableTree(d, 100, false)
+	tree, err := NewMutableTree(d, 100)
 	require.NoError(err)
 	versions := 50
 	keysPerVersion := 10
@@ -1010,7 +1010,7 @@ func TestVersionedCheckpointsSpecialCase3(t *testing.T) {
 }
 
 func TestVersionedCheckpointsSpecialCase4(t *testing.T) {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(t, err)
 
 	tree.Set([]byte("U"), []byte("XamDUtiJ"))
@@ -1129,7 +1129,7 @@ func TestVersionedCheckpointsSpecialCase7(t *testing.T) {
 
 func TestVersionedTreeEfficiency(t *testing.T) {
 	require := require.New(t)
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 0)
 	require.NoError(err)
 	versions := 20
 	keysPerVersion := 100
@@ -1262,7 +1262,7 @@ func TestOrphans(t *testing.T) {
 	// Then randomly delete versions other than the first and last until only those two remain
 	// Any remaining orphan nodes should either have fromVersion == firstVersion || toVersion == lastVersion
 	require := require.New(t)
-	tree, err := NewMutableTree(db.NewMemDB(), 100, false)
+	tree, err := NewMutableTree(db.NewMemDB(), 100)
 	require.NoError(err)
 
 	NUMVERSIONS := 100
@@ -1428,7 +1428,7 @@ func TestOverwrite(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0)
 	require.NoError(err)
 
 	// Set one kv pair and save version 1
@@ -1442,7 +1442,7 @@ func TestOverwrite(t *testing.T) {
 	require.NoError(err, "SaveVersion should not fail")
 
 	// Reload tree at version 1
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0)
 	require.NoError(err)
 	_, err = tree.LoadVersion(int64(1))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1462,7 +1462,7 @@ func TestOverwriteEmpty(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0)
 	require.NoError(err)
 
 	// Save empty version 1
@@ -1497,7 +1497,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 	require := require.New(t)
 
 	mdb := db.NewMemDB()
-	tree, err := NewMutableTree(mdb, 0, false)
+	tree, err := NewMutableTree(mdb, 0)
 	require.NoError(err)
 
 	maxLength := 100
@@ -1509,12 +1509,12 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 		require.NoError(err, "SaveVersion should not fail")
 	}
 
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0)
 	require.NoError(err)
 	targetVersion, _ := tree.LoadVersionForOverwriting(int64(maxLength * 2))
 	require.Equal(targetVersion, int64(maxLength), "targetVersion shouldn't larger than the actual tree latest version")
 
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0)
 	require.NoError(err)
 	_, err = tree.LoadVersionForOverwriting(int64(maxLength / 2))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1538,7 +1538,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 	require.NoError(err, "SaveVersion should not fail, overwrite was allowed")
 
 	// Reload tree at version 50, the latest tree version is 52
-	tree, err = NewMutableTree(mdb, 0, false)
+	tree, err = NewMutableTree(mdb, 0)
 	require.NoError(err)
 	_, err = tree.LoadVersion(int64(maxLength / 2))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1571,7 +1571,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	const fromLength = 5
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1585,7 +1585,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1598,7 +1598,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	}
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1612,7 +1612,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1627,7 +1627,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 	}
 	{
 		mdb := db.NewMemDB()
-		tree, err := NewMutableTree(mdb, 0, false)
+		tree, err := NewMutableTree(mdb, 0)
 		require.NoError(err)
 
 		versions := make([]int64, 0, maxLength)
@@ -1641,7 +1641,7 @@ func TestDeleteVersionsCompare(t *testing.T) {
 			require.NoError(err, "SaveVersion should not fail")
 		}
 
-		tree, err = NewMutableTree(mdb, 0, false)
+		tree, err = NewMutableTree(mdb, 0)
 		require.NoError(err)
 		targetVersion, err := tree.LoadVersion(int64(maxLength))
 		require.NoError(err)
@@ -1670,7 +1670,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 	defer d.Close()
 	defer os.RemoveAll("./bench.db")
 
-	tree, err := NewMutableTree(d, 0, false)
+	tree, err := NewMutableTree(d, 0)
 	require.NoError(b, err)
 	for v := 1; v < numVersions; v++ {
 		for i := 0; i < numKeysPerVersion; i++ {
@@ -1682,7 +1682,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 	b.Run("LoadAndDelete", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
 			b.StopTimer()
-			tree, err = NewMutableTree(d, 0, false)
+			tree, err = NewMutableTree(d, 0)
 			require.NoError(b, err)
 			runtime.GC()
 			b.StartTimer()
@@ -1706,7 +1706,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 func TestLoadVersionForOverwritingCase2(t *testing.T) {
 	require := require.New(t)
 
-	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil)
 
 	for i := byte(0); i < 20; i++ {
 		tree.Set([]byte{i}, []byte{i})
@@ -1768,7 +1768,7 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	require := require.New(t)
 
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false)
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil)
 	require.NoError(err)
 
 	for i := byte(0); i < 20; i++ {
@@ -1899,7 +1899,7 @@ func Benchmark_GetWithIndex(b *testing.B) {
 
 	const numKeyVals = 100000
 
-	t, err := NewMutableTree(db, numKeyVals, false)
+	t, err := NewMutableTree(db, numKeyVals)
 	require.NoError(b, err)
 
 	keys := make([][]byte, 0, numKeyVals)
@@ -1951,7 +1951,7 @@ func Benchmark_GetByIndex(b *testing.B) {
 
 	const numKeyVals = 100000
 
-	t, err := NewMutableTree(db, numKeyVals, false)
+	t, err := NewMutableTree(db, numKeyVals)
 	require.NoError(b, err)
 
 	for i := 0; i < numKeyVals; i++ {
@@ -2027,7 +2027,7 @@ func TestNodeCacheStatisic(t *testing.T) {
 			opts := &Options{Stat: stat}
 			db, err := db.NewDB("test", db.MemDBBackend, "")
 			require.NoError(t, err)
-			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts, false)
+			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts)
 			require.NoError(t, err)
 
 			for i := 0; i < numKeyVals; i++ {


### PR DESCRIPTION

This reverts commit fcab55635ec3caab0c347533b592d6cb4b0095cf.



This commit has cost the ecosystem thousands of man hours and should be tossed, please.  Matching PR's coming in.