### PR TITLE
lint v0.19.x

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,25 @@
-name: Lint
-# Lint runs golangci-lint over the entire cosmos-sdk repository
-# This workflow is run on every pull request and push to master
-# The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
+name: golangci-lint
 on:
-  pull_request:
   push:
+    tags:
+      - v*
     branches:
       - master
+      - main
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  # pull-requests: read
 jobs:
   golangci:
-    name: golangci-lint
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
+      - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,17 +15,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: technote-space/get-diff-action@v6.1.0
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --out-format=tab
-          skip-go-installation: true
-        if: env.GIT_DIFF

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,15 +7,13 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
-    # - errcheck
+    - errcheck
     - exportloopref
     - goconst
     - gocritic
-    - gofmt
-    - goimports
+    - gofumpt
     - gosec
     - gosimple
     - govet
@@ -26,19 +24,23 @@ linters:
     - prealloc
     - revive
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    # - wsl
 
 issues:
   exclude-rules:
+    - text: "leading space"
+      linters:
+        - nolintlint
     - text: "Use of weak random number generator"
       linters:
         - gosec
+    - text: "receiver-naming"
+      linters:
+        - revive
     - text: "comment on exported var"
       linters:
         - golint

--- a/benchmarks/cosmos-exim/main.go
+++ b/benchmarks/cosmos-exim/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -158,7 +157,7 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 	totalStats := Stats{}
 
 	for _, name := range stores {
-		tempdir, err := ioutil.TempDir("", name)
+		tempdir, err := os.MkdirTemp("", name)
 		if err != nil {
 			return err
 		}

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -131,7 +131,7 @@ func ReadTree(dir string, version int, prefix []byte) (*iavl.MutableTree, error)
 
 func PrintKeys(tree *iavl.MutableTree) {
 	fmt.Println("Printing all keys with hashed values (to detect diff)")
-	tree.Iterate(func(key []byte, value []byte) bool {
+	tree.Iterate(func(key []byte, value []byte) bool { //nolint:errcheck
 		printKey := parseWeaveKey(key)
 		digest := sha256.Sum256(value)
 		fmt.Printf("  %s\n    %X\n", printKey, digest)
@@ -163,7 +163,7 @@ func encodeID(id []byte) string {
 
 func PrintShape(tree *iavl.MutableTree) {
 	// shape := tree.RenderShape("  ", nil)
-	//TODO: handle this error
+	// TODO: handle this error
 	shape, _ := tree.RenderShape("  ", nodeEncoder)
 	fmt.Println(strings.Join(shape, "\n"))
 }

--- a/doc.go
+++ b/doc.go
@@ -6,49 +6,47 @@
 // MutableTree.GetImmutable() which are safe for concurrent use as long as
 // the version is not deleted via DeleteVersion().
 //
-//
 // Basic usage of MutableTree:
 //
-//  import "github.com/cosmos/iavl"
-//  import "github.com/tendermint/tm-db"
-//  ...
+//	import "github.com/cosmos/iavl"
+//	import "github.com/tendermint/tm-db"
+//	...
 //
-//  tree := iavl.NewMutableTree(db.NewMemDB(), 128)
+//	tree := iavl.NewMutableTree(db.NewMemDB(), 128)
 //
-//  tree.IsEmpty() // true
+//	tree.IsEmpty() // true
 //
-//  tree.Set([]byte("alice"), []byte("abc"))
-//  tree.SaveVersion(1)
+//	tree.Set([]byte("alice"), []byte("abc"))
+//	tree.SaveVersion(1)
 //
-//  tree.Set([]byte("alice"), []byte("xyz"))
-//  tree.Set([]byte("bob"), []byte("xyz"))
-//  tree.SaveVersion(2)
+//	tree.Set([]byte("alice"), []byte("xyz"))
+//	tree.Set([]byte("bob"), []byte("xyz"))
+//	tree.SaveVersion(2)
 //
-//  tree.LatestVersion() // 2
+//	tree.LatestVersion() // 2
 //
-//  tree.GetVersioned([]byte("alice"), 1) // "abc"
-//  tree.GetVersioned([]byte("alice"), 2) // "xyz"
+//	tree.GetVersioned([]byte("alice"), 1) // "abc"
+//	tree.GetVersioned([]byte("alice"), 2) // "xyz"
 //
 // Proof of existence:
 //
-//  root := tree.Hash()
-//  val, proof, err := tree.GetVersionedWithProof([]byte("bob"), 2) // "xyz", RangeProof, nil
-//  proof.Verify([]byte("bob"), val, root) // nil
+//	root := tree.Hash()
+//	val, proof, err := tree.GetVersionedWithProof([]byte("bob"), 2) // "xyz", RangeProof, nil
+//	proof.Verify([]byte("bob"), val, root) // nil
 //
 // Proof of absence:
 //
-//  _, proof, err = tree.GetVersionedWithProof([]byte("tom"), 2) // nil, RangeProof, nil
-//  proof.Verify([]byte("tom"), nil, root) // nil
+//	_, proof, err = tree.GetVersionedWithProof([]byte("tom"), 2) // nil, RangeProof, nil
+//	proof.Verify([]byte("tom"), nil, root) // nil
 //
 // Now we delete an old version:
 //
-//  tree.DeleteVersion(1)
-//  tree.VersionExists(1) // false
-//  tree.Get([]byte("alice")) // "xyz"
-//  tree.GetVersioned([]byte("alice"), 1) // nil
+//	tree.DeleteVersion(1)
+//	tree.VersionExists(1) // false
+//	tree.Get([]byte("alice")) // "xyz"
+//	tree.GetVersioned([]byte("alice"), 1) // nil
 //
 // Can't create a proof of absence for a version we no longer have:
 //
-//  _, proof, err = tree.GetVersionedWithProof([]byte("tom"), 1) // nil, nil, error
-//
+//	_, proof, err = tree.GetVersionedWithProof([]byte("tom"), 1) // nil, nil, error
 package iavl

--- a/docs/node/node.md
+++ b/docs/node/node.md
@@ -1,23 +1,23 @@
 # Node
 
-The Node struct stores a node in the IAVL tree. 
+The Node struct stores a node in the IAVL tree.
 
 ### Structure
 
 ```golang
 // Node represents a node in a Tree.
 type Node struct {
-	key       []byte // key for the node.
-	value     []byte // value of leaf node. If inner node, value = nil
-	version   int64  // The version of the IAVL that this node was first added in.
-	height    int8   // The height of the node. Leaf nodes have height 0
-	size      int64  // The number of leaves that are under the current node. Leaf nodes have size = 1
-	hash      []byte // hash of above field and leftHash, rightHash
-	leftHash  []byte // hash of left child
-	leftNode  *Node  // pointer to left child
+ key       []byte // key for the node.
+ value     []byte // value of leaf node. If inner node, value = nil
+ version   int64  // The version of the IAVL that this node was first added in.
+ height    int8   // The height of the node. Leaf nodes have height 0
+ size      int64  // The number of leaves that are under the current node. Leaf nodes have size = 1
+ hash      []byte // hash of above field and leftHash, rightHash
+ leftHash  []byte // hash of left child
+ leftNode  *Node  // pointer to left child
         rightHash []byte // hash of right child
-	rightNode *Node  // pointer to right child
-	persisted bool   // persisted to disk
+ rightNode *Node  // pointer to right child
+ persisted bool   // persisted to disk
 }
 ```
 
@@ -27,55 +27,55 @@ The version of a node is the first version of the IAVL tree that the node gets a
 
 Size is the number of leaves under a given node. With a full subtree, `node.size = 2^(node.height)`.
 
-### Marshaling 
+### Marshaling
 
 Every node is persisted by encoding the key, version, height, size and hash. If the node is a leaf node, then the value is persisted as well. If the node is not a leaf node, then the leftHash and rightHash are persisted as well.
 
 ```golang
 // Writes the node as a serialized byte slice to the supplied io.Writer.
-func (node *Node) writeBytes(w io.Writer) error {
-	cause := encodeVarint(w, node.height)
-	if cause != nil {
-		return errors.Wrap(cause, "writing height")
-	}
-	cause = encodeVarint(w, node.size)
-	if cause != nil {
-		return errors.Wrap(cause, "writing size")
-	}
-	cause = encodeVarint(w, node.version)
-	if cause != nil {
-		return errors.Wrap(cause, "writing version")
-	}
+func (n *Node) writeBytes(w io.Writer) error {
+ cause := encodeVarint(w, node.height)
+ if cause != nil {
+  return errors.Wrap(cause, "writing height")
+ }
+ cause = encodeVarint(w, node.size)
+ if cause != nil {
+  return errors.Wrap(cause, "writing size")
+ }
+ cause = encodeVarint(w, node.version)
+ if cause != nil {
+  return errors.Wrap(cause, "writing version")
+ }
 
-	// Unlike writeHashBytes, key is written for inner nodes.
-	cause = encodeBytes(w, node.key)
-	if cause != nil {
-		return errors.Wrap(cause, "writing key")
-	}
+ // Unlike writeHashBytes, key is written for inner nodes.
+ cause = encodeBytes(w, node.key)
+ if cause != nil {
+  return errors.Wrap(cause, "writing key")
+ }
 
-	if node.isLeaf() {
-		cause = encodeBytes(w, node.value)
-		if cause != nil {
-			return errors.Wrap(cause, "writing value")
-		}
-	} else {
-		if node.leftHash == nil {
-			panic("node.leftHash was nil in writeBytes")
-		}
-		cause = encodeBytes(w, node.leftHash)
-		if cause != nil {
-			return errors.Wrap(cause, "writing left hash")
-		}
+ if node.isLeaf() {
+  cause = encodeBytes(w, node.value)
+  if cause != nil {
+   return errors.Wrap(cause, "writing value")
+  }
+ } else {
+  if node.leftHash == nil {
+   panic("node.leftHash was nil in writeBytes")
+  }
+  cause = encodeBytes(w, node.leftHash)
+  if cause != nil {
+   return errors.Wrap(cause, "writing left hash")
+  }
 
-		if node.rightHash == nil {
-			panic("node.rightHash was nil in writeBytes")
-		}
-		cause = encodeBytes(w, node.rightHash)
-		if cause != nil {
-			return errors.Wrap(cause, "writing right hash")
-		}
-	}
-	return nil
+  if node.rightHash == nil {
+   panic("node.rightHash was nil in writeBytes")
+  }
+  cause = encodeBytes(w, node.rightHash)
+  if cause != nil {
+   return errors.Wrap(cause, "writing right hash")
+  }
+ }
+ return nil
 }
 ```
 
@@ -86,48 +86,48 @@ A node's hash is calculated by hashing the height, size, and version of the node
 ```golang
 // Writes the node's hash to the given io.Writer. This function expects
 // child hashes to be already set.
-func (node *Node) writeHashBytes(w io.Writer) error {
-	err := encodeVarint(w, node.height)
-	if err != nil {
-		return errors.Wrap(err, "writing height")
-	}
-	err = encodeVarint(w, node.size)
-	if err != nil {
-		return errors.Wrap(err, "writing size")
-	}
-	err = encodeVarint(w, node.version)
-	if err != nil {
-		return errors.Wrap(err, "writing version")
-	}
+func (n *Node) writeHashBytes(w io.Writer) error {
+ err := encodeVarint(w, node.height)
+ if err != nil {
+  return errors.Wrap(err, "writing height")
+ }
+ err = encodeVarint(w, node.size)
+ if err != nil {
+  return errors.Wrap(err, "writing size")
+ }
+ err = encodeVarint(w, node.version)
+ if err != nil {
+  return errors.Wrap(err, "writing version")
+ }
 
-	// Key is not written for inner nodes, unlike writeBytes.
+ // Key is not written for inner nodes, unlike writeBytes.
 
-	if node.isLeaf() {
-		err = encodeBytes(w, node.key)
-		if err != nil {
-			return errors.Wrap(err, "writing key")
-		}
-		// Indirection needed to provide proofs without values.
-		// (e.g. proofLeafNode.ValueHash)
-		valueHash := tmhash.Sum(node.value)
-		err = encodeBytes(w, valueHash)
-		if err != nil {
-			return errors.Wrap(err, "writing value")
-		}
-	} else {
-		if node.leftHash == nil || node.rightHash == nil {
-			panic("Found an empty child hash")
-		}
-		err = encodeBytes(w, node.leftHash)
-		if err != nil {
-			return errors.Wrap(err, "writing left hash")
-		}
-		err = encodeBytes(w, node.rightHash)
-		if err != nil {
-			return errors.Wrap(err, "writing right hash")
-		}
-	}
+ if node.isLeaf() {
+  err = encodeBytes(w, node.key)
+  if err != nil {
+   return errors.Wrap(err, "writing key")
+  }
+  // Indirection needed to provide proofs without values.
+  // (e.g. proofLeafNode.ValueHash)
+  valueHash := tmhash.Sum(node.value)
+  err = encodeBytes(w, valueHash)
+  if err != nil {
+   return errors.Wrap(err, "writing value")
+  }
+ } else {
+  if node.leftHash == nil || node.rightHash == nil {
+   panic("Found an empty child hash")
+  }
+  err = encodeBytes(w, node.leftHash)
+  if err != nil {
+   return errors.Wrap(err, "writing left hash")
+  }
+  err = encodeBytes(w, node.rightHash)
+  if err != nil {
+   return errors.Wrap(err, "writing right hash")
+  }
+ }
 
-	return nil
+ return nil
 }
 ```

--- a/export.go
+++ b/export.go
@@ -12,8 +12,9 @@ import (
 const exportBufferSize = 32
 
 // ExportDone is returned by Exporter.Next() when all items have been exported.
-// nolint:revive
-var ExportDone = errors.New("export is complete") // nolint:golint
+//
+//nolint:revive
+var ExportDone = errors.New("export is complete") //nolint:golint
 
 // ExportNode contains exported node data.
 type ExportNode struct {

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -45,7 +45,7 @@ func NewImmutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastS
 // String returns a string representation of Tree.
 func (t *ImmutableTree) String() string {
 	leaves := []string{}
-	t.Iterate(func(key []byte, val []byte) (stop bool) {
+	t.Iterate(func(key []byte, val []byte) (stop bool) { //nolint:errcheck
 		leaves = append(leaves, fmt.Sprintf("%x: %x", key, val))
 		return false
 	})
@@ -231,15 +231,15 @@ func (t *ImmutableTree) Iterate(fn func(key []byte, value []byte) bool) (bool, e
 	}
 
 	itr, err := t.Iterator(nil, nil, true)
-	defer itr.Close()
 	if err != nil {
 		return false, err
 	}
+	defer itr.Close()
+
 	for ; itr.Valid(); itr.Next() {
 		if fn(itr.Key(), itr.Value()) {
 			return true, nil
 		}
-
 	}
 	return false, nil
 }

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 )
 
-var (
-	debugging = false
-)
+var debugging = false
 
 func Debug(format string, args ...interface{}) {
 	if debugging {

--- a/iterator.go
+++ b/iterator.go
@@ -76,19 +76,19 @@ func (nodes *delayedNodes) length() int {
 // 1. If it is not an delayed node (node.delayed == false) it immediately returns it.
 //
 // A. If the `node` is a branch node:
-// 1. If the traversal is postorder, then append the current node to the t.delayedNodes,
-//    with `delayed` set to false. This makes the current node returned *after* all the children
-//    are traversed, without being expanded.
-// 2. Append the traversable children nodes into the `delayedNodes`, with `delayed` set to true. This
-//    makes the children nodes to be traversed, and expanded with their respective children.
-// 3. If the traversal is preorder, (with the children to be traversed already pushed to the
-//    `delayedNodes`), returns the current node.
-// 4. Call `traversal.next()` to further traverse through the `delayedNodes`.
+//  1. If the traversal is postorder, then append the current node to the t.delayedNodes,
+//     with `delayed` set to false. This makes the current node returned *after* all the children
+//     are traversed, without being expanded.
+//  2. Append the traversable children nodes into the `delayedNodes`, with `delayed` set to true. This
+//     makes the children nodes to be traversed, and expanded with their respective children.
+//  3. If the traversal is preorder, (with the children to be traversed already pushed to the
+//     `delayedNodes`), returns the current node.
+//  4. Call `traversal.next()` to further traverse through the `delayedNodes`.
 //
 // B. If the `node` is a leaf node, it will be returned without expand, by the following process:
-// 1. If the traversal is postorder, the current node will be append to the `delayedNodes` with `delayed`
-//    set to false, and immediately returned at the subsequent call of `traversal.next()` at the last line.
-// 2. If the traversal is preorder, the current node will be returned.
+//  1. If the traversal is postorder, the current node will be append to the `delayedNodes` with `delayed`
+//     set to false, and immediately returned at the subsequent call of `traversal.next()` at the last line.
+//  2. If the traversal is preorder, the current node will be returned.
 func (t *traversal) next() (*Node, error) {
 	// End of traversal.
 	if t.delayedNodes.length() == 0 {

--- a/key_format.go
+++ b/key_format.go
@@ -19,15 +19,16 @@ type KeyFormat struct {
 // For example, to store keys that could index some objects by a version number and their SHA256 hash using the form:
 // 'c<version uint64><hash [32]byte>' then you would define the KeyFormat with:
 //
-//  var keyFormat = NewKeyFormat('c', 8, 32)
+//	var keyFormat = NewKeyFormat('c', 8, 32)
 //
 // Then you can create a key with:
 //
-//  func ObjectKey(version uint64, objectBytes []byte) []byte {
-//  	hasher := sha256.New()
-//  	hasher.Sum(nil)
-//  	return keyFormat.Key(version, hasher.Sum(nil))
-//  }
+//	func ObjectKey(version uint64, objectBytes []byte) []byte {
+//		hasher := sha256.New()
+//		hasher.Sum(nil)
+//		return keyFormat.Key(version, hasher.Sum(nil))
+//	}
+//
 // if the last term of the layout ends in 0
 func NewKeyFormat(prefix byte, layout ...int) *KeyFormat {
 	// For prefix byte

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -717,7 +717,10 @@ func (tree *MutableTree) enableFastStorageAndCommit() error {
 			return err
 		}
 		if upgradedFastNodes%commitGap == 0 {
-			tree.ndb.Commit()
+			err = tree.ndb.Commit()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/node.go
+++ b/node.go
@@ -49,7 +49,6 @@ func NewNode(key []byte, value []byte, version int64) *Node {
 // The new node doesn't have its hash saved or set. The caller must set it
 // afterwards.
 func MakeNode(buf []byte) (*Node, error) {
-
 	// Read node header (height, size, version, key).
 	height, n, cause := encoding.DecodeVarint(buf)
 	if cause != nil {

--- a/nodedb.go
+++ b/nodedb.go
@@ -65,9 +65,7 @@ var (
 	rootKeyFormat = NewKeyFormat('r', int64Size) // r<version>
 )
 
-var (
-	errInvalidFastStorageVersion = fmt.Sprintf("Fast storage version must be in the format <storage version>%s<latest fast cache version>", fastStorageVersionDelimiter)
-)
+var errInvalidFastStorageVersion = fmt.Sprintf("Fast storage version must be in the format <storage version>%s<latest fast cache version>", fastStorageVersionDelimiter)
 
 type nodeDB struct {
 	mtx            sync.Mutex       // Read/write lock.
@@ -491,7 +489,6 @@ func (ndb *nodeDB) DeleteVersionsFrom(version int64) error {
 	err = ndb.traverseFastNodes(func(keyWithPrefix, v []byte) error {
 		key := keyWithPrefix[1:]
 		fastNode, err := DeserializeFastNode(key, v)
-
 		if err != nil {
 			return err
 		}
@@ -697,7 +694,10 @@ func (ndb *nodeDB) deleteOrphans(version int64) error {
 			ndb.nodeCache.Remove(hash)
 		} else {
 			logger.Debug("MOVE predecessor:%v fromVersion:%v toVersion:%v %X\n", predecessor, fromVersion, toVersion, hash)
-			ndb.saveOrphan(hash, fromVersion, predecessor)
+			err := ndb.saveOrphan(hash, fromVersion, predecessor)
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	})
@@ -965,7 +965,6 @@ func (ndb *nodeDB) leafNodes() ([]*Node, error) {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -981,7 +980,6 @@ func (ndb *nodeDB) nodes() ([]*Node, error) {
 		nodes = append(nodes, node)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -997,7 +995,6 @@ func (ndb *nodeDB) orphans() ([][]byte, error) {
 		orphans = append(orphans, v)
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -1008,6 +1005,7 @@ func (ndb *nodeDB) orphans() ([][]byte, error) {
 // Not efficient.
 // NOTE: DB cannot implement Size() because
 // mutations are not always synchronous.
+//
 //nolint:unused
 func (ndb *nodeDB) size() int {
 	size := 0
@@ -1015,7 +1013,6 @@ func (ndb *nodeDB) size() int {
 		size++
 		return nil
 	})
-
 	if err != nil {
 		return -1
 	}
@@ -1034,7 +1031,6 @@ func (ndb *nodeDB) traverseNodes(fn func(hash []byte, node *Node) error) error {
 		nodes = append(nodes, node)
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -1062,7 +1058,6 @@ func (ndb *nodeDB) String() (string, error) {
 		fmt.Fprintf(buf, "%s: %x\n", key, value)
 		return nil
 	})
-
 	if err != nil {
 		return "", err
 	}

--- a/proof.go
+++ b/proof.go
@@ -187,7 +187,6 @@ func (pln ProofLeafNode) Hash() ([]byte, error) {
 	_, err = hasher.Write(buf.Bytes())
 	if err != nil {
 		return nil, err
-
 	}
 
 	return hasher.Sum(nil), nil

--- a/proof_range.go
+++ b/proof_range.go
@@ -175,7 +175,6 @@ func (proof *RangeProof) VerifyAbsence(key []byte) error {
 		return errors.New("absence not proved by right leaf (need another leaf?)")
 	}
 	return errors.New("absence not proved by right leaf")
-
 }
 
 // Verify that proof is valid.
@@ -236,15 +235,14 @@ func (proof *RangeProof) _computeRootHash() (rootHash []byte, treeEnd bool, err 
 	// Start from the left path and prove each leaf.
 
 	// shared across recursive calls
-	var leaves = proof.Leaves
-	var innersq = proof.InnerNodes
+	leaves := proof.Leaves
+	innersq := proof.InnerNodes
 	var COMPUTEHASH func(path PathToLeaf, rightmost bool) (hash []byte, treeEnd bool, done bool, err error)
 
 	// rightmost: is the root a rightmost child of the tree?
 	// treeEnd: true iff the last leaf is the last item of the tree.
 	// Returns the (possibly intermediate, possibly root) hash.
 	COMPUTEHASH = func(path PathToLeaf, rightmost bool) (hash []byte, treeEnd bool, done bool, err error) {
-
 		// Pop next leaf.
 		nleaf, rleaves := leaves[0], leaves[1:]
 		leaves = rleaves
@@ -416,7 +414,7 @@ func (t *ImmutableTree) getRangeProof(keyStart, keyEnd []byte, limit int) (proof
 	}
 
 	h := sha256.Sum256(left.value)
-	var leaves = []ProofLeafNode{
+	leaves := []ProofLeafNode{
 		{
 			Key:       left.key,
 			ValueHash: h[:],
@@ -444,14 +442,13 @@ func (t *ImmutableTree) getRangeProof(keyStart, keyEnd []byte, limit int) (proof
 
 	// Traverse starting from afterLeft, until keyEnd or the next leaf
 	// after keyEnd.
-	var allPathToLeafs = []PathToLeaf(nil)
-	var currentPathToLeaf = PathToLeaf(nil)
-	var leafCount = 1 // from left above.
-	var pathCount = 0
+	allPathToLeafs := []PathToLeaf(nil)
+	currentPathToLeaf := PathToLeaf(nil)
+	leafCount := 1 // from left above.
+	pathCount := 0
 
 	t.root.traverseInRange(t, afterLeft, nil, true, false, false,
 		func(node *Node) (stop bool) {
-
 			// Track when we diverge from path, or when we've exhausted path,
 			// since the first allPathToLeafs shouldn't include it.
 			if pathCount != -1 {
@@ -571,8 +568,8 @@ func (tree *MutableTree) GetVersionedWithProof(key []byte, version int64) ([]byt
 // GetVersionedRangeWithProof gets key/value pairs within the specified range
 // and limit.
 func (tree *MutableTree) GetVersionedRangeWithProof(startKey, endKey []byte, limit int, version int64) (
-	keys, values [][]byte, proof *RangeProof, err error) {
-
+	keys, values [][]byte, proof *RangeProof, err error,
+) {
 	if tree.VersionExists(version) {
 		t, err := tree.GetImmutable(version)
 		if err != nil {

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -353,7 +353,7 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 	}
 }
 
-func (n *Node) lmd(t *ImmutableTree) *Node {
+func (node *Node) lmd(t *ImmutableTree) *Node {
 	if node.isLeaf() {
 		return node
 	}

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -4,11 +4,10 @@ package iavl
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
 	"runtime"
 	"sort"
 	"testing"
-
-	"math/rand"
 
 	"github.com/stretchr/testify/require"
 	db "github.com/tendermint/tm-db"
@@ -354,7 +353,7 @@ func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
 	}
 }
 
-func (node *Node) lmd(t *ImmutableTree) *Node {
+func (n *Node) lmd(t *ImmutableTree) *Node {
 	if node.isLeaf() {
 		return node
 	}

--- a/tree_dotgraph.go
+++ b/tree_dotgraph.go
@@ -45,7 +45,7 @@ func WriteDOTGraph(w io.Writer, tree *ImmutableTree, paths []PathToLeaf) {
 	ctx := &graphContext{}
 
 	// TODO: handle error
-	tree.root.hashWithCount()
+	tree.root.hashWithCount() //nolint:errcheck
 	tree.root.traverse(tree, true, func(node *Node) bool {
 		graphNode := &graphNode{
 			Attrs: map[string]string{},

--- a/util.go
+++ b/util.go
@@ -9,7 +9,7 @@ import (
 // PrintTree prints the whole tree in an indented form.
 func PrintTree(tree *ImmutableTree) {
 	ndb, root := tree.ndb, tree.root
-	printNode(ndb, root, 0)
+	printNode(ndb, root, 0) //nolint:errcheck
 }
 
 func printNode(ndb *nodeDB, node *Node, indent int) error {
@@ -23,13 +23,19 @@ func printNode(ndb *nodeDB, node *Node, indent int) error {
 		return nil
 	}
 	if node.rightNode != nil {
-		printNode(ndb, node.rightNode, indent+1)
+		err := printNode(ndb, node.rightNode, indent+1)
+		if err != nil {
+			return err
+		}
 	} else if node.rightHash != nil {
 		rightNode, err := ndb.GetNode(node.rightHash)
 		if err != nil {
 			return err
 		}
-		printNode(ndb, rightNode, indent+1)
+		err = printNode(ndb, rightNode, indent+1)
+		if err != nil {
+			return err
+		}
 	}
 
 	hash, err := node._hash()
@@ -43,13 +49,19 @@ func printNode(ndb *nodeDB, node *Node, indent int) error {
 	}
 
 	if node.leftNode != nil {
-		printNode(ndb, node.leftNode, indent+1)
+		err := printNode(ndb, node.leftNode, indent+1)
+		if err != nil {
+			return err
+		}
 	} else if node.leftHash != nil {
 		leftNode, err := ndb.GetNode(node.leftHash)
 		if err != nil {
 			return err
 		}
-		printNode(ndb, leftNode, indent+1)
+		err = printNode(ndb, leftNode, indent+1)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/version.go
+++ b/version.go
@@ -33,5 +33,6 @@ func GetVersionInfo() VersionInfo {
 		Version,
 		Commit,
 		Branch,
-		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)}
+		fmt.Sprintf("go version %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH),
+	}
 }


### PR DESCRIPTION
A separate PR for linting vs cosmos-db, so that each is easier to read. 

This just vigorously applies golangci-lint run ./... --fix

notably, this found a decent number of unchecked errors
