### PR TITLE
Revert "fix: Prevent newExporter crash if tree.ndb is nil (backport #622)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-### Breaking Changes
-
-- [#622](https://github.com/cosmos/iavl/pull/622) `export/newExporter()` and `ImmutableTree.Export()` returns error for nil arguements
-
 ## Unreleased
 
 - [#640](https://github.com/cosmos/iavl/pull/640) commit `NodeDB` batch in `LoadVersionForOverwriting`.

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,10 @@ all: lint test install
 install:
 ifeq ($(COLORS_ON),)
 	go install ./cmd/iaviewer
+	go install ./cmd/iavlserver
 else
 	go install $(CMDFLAGS) ./cmd/iaviewer
+	go install $(CMDFLAGS) ./cmd/iavlserver
 endif
 .PHONY: install
 

--- a/benchmarks/cosmos-exim/main.go
+++ b/benchmarks/cosmos-exim/main.go
@@ -128,10 +128,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 			return 0, nil, err
 		}
 		start := time.Now().UTC()
-		exporter, err := itree.Export()
-		if err != nil {
-			return 0, nil, err
-		}
+		exporter := itree.Export()
 		defer exporter.Close()
 		for {
 			node, err := exporter.Next()

--- a/export.go
+++ b/export.go
@@ -36,6 +36,13 @@ type Exporter struct {
 
 // NewExporter creates a new Exporter. Callers must call Close() when done.
 func newExporter(tree *ImmutableTree) *Exporter {
+	if tree == nil {
+		return nil
+	}
+	// CV Prevent crash on incrVersionReaders if tree.ndb == nil
+	if tree.ndb == nil {
+		return nil
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	exporter := &Exporter{
 		tree:   tree,

--- a/export.go
+++ b/export.go
@@ -2,8 +2,8 @@ package iavl
 
 import (
 	"context"
-	"errors"
-	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 // exportBufferSize is the number of nodes to buffer in the exporter. It improves throughput by
@@ -14,9 +14,6 @@ const exportBufferSize = 32
 // ExportDone is returned by Exporter.Next() when all items have been exported.
 // nolint:revive
 var ExportDone = errors.New("export is complete") // nolint:golint
-
-// ErrNotInitalizedTree when chains introduce a store without initializing data
-var ErrNotInitalizedTree = errors.New("iavl/export newExporter failed to create")
 
 // ExportNode contains exported node data.
 type ExportNode struct {
@@ -38,15 +35,7 @@ type Exporter struct {
 }
 
 // NewExporter creates a new Exporter. Callers must call Close() when done.
-func newExporter(tree *ImmutableTree) (*Exporter, error) {
-	if tree == nil {
-		return nil, fmt.Errorf("tree is nil: %w", ErrNotInitalizedTree)
-	}
-	// CV Prevent crash on incrVersionReaders if tree.ndb == nil
-	if tree.ndb == nil {
-		return nil, fmt.Errorf("tree.ndb is nil: %w", ErrNotInitalizedTree)
-	}
-
+func newExporter(tree *ImmutableTree) *Exporter {
 	ctx, cancel := context.WithCancel(context.Background())
 	exporter := &Exporter{
 		tree:   tree,
@@ -57,7 +46,7 @@ func newExporter(tree *ImmutableTree) (*Exporter, error) {
 	tree.ndb.incrVersionReaders(tree.version)
 	go exporter.export(ctx)
 
-	return exporter, nil
+	return exporter
 }
 
 // export exports nodes

--- a/export_test.go
+++ b/export_test.go
@@ -160,8 +160,7 @@ func TestExporter(t *testing.T) {
 	}
 
 	actual := make([]*ExportNode, 0, len(expect))
-	exporter, err := tree.Export()
-	require.NoError(t, err)
+	exporter := tree.Export()
 	defer exporter.Close()
 	for {
 		node, err := exporter.Next()
@@ -190,8 +189,7 @@ func TestExporter_Import(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			t.Parallel()
 
-			exporter, err := tree.Export()
-			require.NoError(t, err)
+			exporter := tree.Export()
 			defer exporter.Close()
 
 			newTree, err := NewMutableTree(db.NewMemDB(), 0, false)
@@ -236,8 +234,7 @@ func TestExporter_Import(t *testing.T) {
 
 func TestExporter_Close(t *testing.T) {
 	tree := setupExportTreeSized(t, 4096)
-	exporter, err := tree.Export()
-	require.NoError(t, err)
+	exporter := tree.Export()
 
 	node, err := exporter.Next()
 	require.NoError(t, err)
@@ -276,8 +273,7 @@ func TestExporter_DeleteVersionErrors(t *testing.T) {
 
 	itree, err := tree.GetImmutable(2)
 	require.NoError(t, err)
-	exporter, err := itree.Export()
-	require.NoError(t, err)
+	exporter := itree.Export()
 	defer exporter.Close()
 
 	err = tree.DeleteVersion(2)
@@ -295,8 +291,7 @@ func BenchmarkExport(b *testing.B) {
 	tree := setupExportTreeSized(b, 4096)
 	b.StartTimer()
 	for n := 0; n < b.N; n++ {
-		exporter, err := tree.Export()
-		require.NoError(b, err)
+		exporter := tree.Export()
 		for {
 			_, err := exporter.Next()
 			if err == ExportDone {

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -155,7 +155,7 @@ func (t *ImmutableTree) Hash() ([]byte, error) {
 
 // Export returns an iterator that exports tree nodes as ExportNodes. These nodes can be
 // imported with MutableTree.Import() to recreate an identical tree.
-func (t *ImmutableTree) Export() (*Exporter, error) {
+func (t *ImmutableTree) Export() *Exporter {
 	return newExporter(t)
 }
 

--- a/import_test.go
+++ b/import_test.go
@@ -27,7 +27,7 @@ func ExampleImporter() {
 	if err != nil {
 		// handle err
 	}
-	exporter, err := itree.Export()
+	exporter := itree.Export()
 	defer exporter.Close()
 	exported := []*ExportNode{}
 	for {
@@ -218,8 +218,7 @@ func BenchmarkImport(b *testing.B) {
 	b.StopTimer()
 	tree := setupExportTreeSized(b, 4096)
 	exported := make([]*ExportNode, 0, 4096)
-	exporter, err := tree.Export()
-	require.NoError(b, err)
+	exporter := tree.Export()
 	for {
 		item, err := exporter.Next()
 		if err == ExportDone {


### PR DESCRIPTION
Reverts cosmos/iavl#631