### PR TITLE
fix: validate branch node must have both children

### DIFF
--- a/node.go
+++ b/node.go
@@ -321,8 +321,8 @@ func (node *Node) validate() error {
 		if node.value != nil {
 			return errors.New("value must be nil for non-leaf node")
 		}
-		if node.leftHash == nil && node.rightHash == nil {
-			return errors.New("inner node must have children")
+		if node.leftHash == nil || node.rightHash == nil {
+			return errors.New("inner node must have both children")
 		}
 	}
 	return nil

--- a/node_test.go
+++ b/node_test.go
@@ -114,8 +114,8 @@ func TestNode_validate(t *testing.T) {
 		"inner with nil key":     {&Node{key: nil, value: v, version: 1, size: 1, subtreeHeight: 1, leftHash: h, rightHash: h}, false},
 		"inner with value":       {&Node{key: k, value: v, version: 1, size: 1, subtreeHeight: 1, leftHash: h, rightHash: h}, false},
 		"inner with empty value": {&Node{key: k, value: []byte{}, version: 1, size: 1, subtreeHeight: 1, leftHash: h, rightHash: h}, false},
-		"inner with left child":  {&Node{key: k, version: 1, size: 1, subtreeHeight: 1, leftHash: h}, true},
-		"inner with right child": {&Node{key: k, version: 1, size: 1, subtreeHeight: 1, rightHash: h}, true},
+		"inner with left child":  {&Node{key: k, version: 1, size: 1, subtreeHeight: 1, leftHash: h}, false},
+		"inner with right child": {&Node{key: k, version: 1, size: 1, subtreeHeight: 1, rightHash: h}, false},
 		"inner with no child":    {&Node{key: k, version: 1, size: 1, subtreeHeight: 1}, false},
 		"inner with height 0":    {&Node{key: k, version: 1, size: 1, subtreeHeight: 0, leftHash: h, rightHash: h}, false},
 	}


### PR DESCRIPTION
This is what confused me when reading the code, to my understanding branch node always have two children, but the code seems to allow single child branch nodes?

marked as draft to wait for feedbacks first.