### PR TITLE
optim: remove the buffer when compute node hash

### DIFF
--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -159,6 +159,9 @@ func EncodeVarint(w io.Writer, i int64) error {
 
 // EncodeVarintSize returns the byte size of the given integer as a varint.
 func EncodeVarintSize(i int64) int {
-	var buf [binary.MaxVarintLen64]byte
-	return binary.PutVarint(buf[:], i)
+	ux := uint64(i) << 1
+	if i < 0 {
+		ux = ^ux
+	}
+	return EncodeUvarintSize(ux)
 }

--- a/node.go
+++ b/node.go
@@ -247,12 +247,7 @@ func (node *Node) _hash() ([]byte, error) {
 	}
 
 	h := sha256.New()
-	buf := new(bytes.Buffer)
-	if err := node.writeHashBytes(buf); err != nil {
-		return nil, err
-	}
-	_, err := h.Write(buf.Bytes())
-	if err != nil {
+	if err := node.writeHashBytes(h); err != nil {
 		return nil, err
 	}
 	node.hash = h.Sum(nil)


### PR DESCRIPTION
- remove the buffer when compute node hash
- benchmark different ways to hash node

```
$ go test -run=^$ -bench=BenchmarkNode_HashNode -benchmem ./ -count=5
goos: darwin
goarch: amd64
pkg: github.com/cosmos/iavl
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkNode_HashNode/NoBuffer-12         	 1571757	       757.0 ns/op	     160 B/op	       2 allocs/op
BenchmarkNode_HashNode/NoBuffer-12         	 1594012	       751.8 ns/op	     160 B/op	       2 allocs/op
BenchmarkNode_HashNode/NoBuffer-12         	 1598257	       757.4 ns/op	     160 B/op	       2 allocs/op
BenchmarkNode_HashNode/NoBuffer-12         	 1578457	       745.4 ns/op	     160 B/op	       2 allocs/op
BenchmarkNode_HashNode/NoBuffer-12         	 1613202	       783.7 ns/op	     160 B/op	       2 allocs/op
BenchmarkNode_HashNode/PreAllocate-12      	 1000000	      1129 ns/op	     160 B/op	       3 allocs/op
BenchmarkNode_HashNode/PreAllocate-12      	 1000000	      1098 ns/op	     160 B/op	       3 allocs/op
BenchmarkNode_HashNode/PreAllocate-12      	  974152	      1088 ns/op	     160 B/op	       3 allocs/op
BenchmarkNode_HashNode/PreAllocate-12      	 1000000	      1083 ns/op	     160 B/op	       3 allocs/op
BenchmarkNode_HashNode/PreAllocate-12      	 1000000	      1084 ns/op	     160 B/op	       3 allocs/op
BenchmarkNode_HashNode/NoPreAllocate-12    	 1000000	      1095 ns/op	     144 B/op	       3 allocs/op
BenchmarkNode_HashNode/NoPreAllocate-12    	 1000000	      1068 ns/op	     144 B/op	       3 allocs/op
BenchmarkNode_HashNode/NoPreAllocate-12    	 1000000	      1068 ns/op	     144 B/op	       3 allocs/op
BenchmarkNode_HashNode/NoPreAllocate-12    	 1000000	      1063 ns/op	     144 B/op	       3 allocs/op
BenchmarkNode_HashNode/NoPreAllocate-12    	 1000000	      1060 ns/op	     144 B/op	       3 allocs/op
PASS
ok  	github.com/cosmos/iavl	22.453s
```