### PR TITLE
Optimize node encoding/decoding with stream-vbyte format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [#646](https://github.com/cosmos/iavl/pull/646) Remove the `orphans` from the storage
 - [#622](https://github.com/cosmos/iavl/pull/622) `export/newExporter()` and `ImmutableTree.Export()` returns error for nil arguements
-- [#]() Optimize node encode/decode speed with stream-vbyte format.
+- [#673](https://github.com/cosmos/iavl/pull/673) Optimize node encode/decode speed with stream-vbyte format.
 
 ### API Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#646](https://github.com/cosmos/iavl/pull/646) Remove the `orphans` from the storage
 - [#622](https://github.com/cosmos/iavl/pull/622) `export/newExporter()` and `ImmutableTree.Export()` returns error for nil arguements
+- [#]() Optimize node encode/decode speed with stream-vbyte format.
 
 ### API Changes
 

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/stretchr/testify v1.8.1
+	github.com/theMPatel/streamvbyte-simdgo v0.4.0
 	golang.org/x/crypto v0.5.0
 )
 
@@ -121,6 +122,7 @@ require (
 	github.com/mgechev/revive v1.2.4 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mmcloughlin/avo v0.2.0 // indirect
 	github.com/moricho/tparallel v0.2.1 // indirect
 	github.com/nakabonne/nestif v0.3.1 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,6 +494,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mmcloughlin/avo v0.2.0 h1:6vhoSaKtxb6f4RiH+LK2qL6GSMpFzhEwJYTTSZNy09w=
+github.com/mmcloughlin/avo v0.2.0/go.mod h1:5tidO2Z9Z7N6X7UMcGg+1KTj51O8OxYDCMHxCZTVpEA=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
@@ -683,6 +685,8 @@ github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3 h1:f+jULpR
 github.com/tenntenn/text/transform v0.0.0-20200319021203-7eef512accb3/go.mod h1:ON8b8w4BN/kE1EOhwT0o+d62W65a6aPw1nouo9LMgyY=
 github.com/tetafro/godot v1.4.11 h1:BVoBIqAf/2QdbFmSwAWnaIqDivZdOV0ZRwEm6jivLKw=
 github.com/tetafro/godot v1.4.11/go.mod h1:LR3CJpxDVGlYOWn3ZZg1PgNZdTUvzsZWu8xaEohUpn8=
+github.com/theMPatel/streamvbyte-simdgo v0.4.0 h1:F4/m66f9Cxe6tyOLkYMaNXhESTEGtuk0hsj/xC67aUk=
+github.com/theMPatel/streamvbyte-simdgo v0.4.0/go.mod h1:gQKkpdYFPOIayvPVArJ8wL5BXnWMyEU7G3y3c+twfI4=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144 h1:kl4KhGNsJIbDHS9/4U9yQo1UcPQM0kOMJHn29EoH/Ro=
 github.com/timakin/bodyclose v0.0.0-20210704033933-f49887972144/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/timonwong/loggercheck v0.9.3 h1:ecACo9fNiHxX4/Bc02rW2+kaJIAMAes7qJ7JKxt0EZI=
@@ -739,6 +743,7 @@ go.uber.org/multierr v1.8.0 h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
 go.uber.org/multierr v1.8.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.22.0 h1:Zcye5DUgBloQ9BaT4qc9BnjOFog5TvBSAGkJ3Nf70c0=
 go.uber.org/zap v1.22.0/go.mod h1:H4siCOZOrAolnUPJEkfaSjDqyP+BDS0DdDWzwcgt3+U=
+golang.org/x/arch v0.0.0-20210405154355-08b684f594a5/go.mod h1:flIaEI6LNU6xOCD5PaJvn9wGP0agmIOqjrtsKGRguv4=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -923,6 +928,7 @@ golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/import.go
+++ b/import.go
@@ -127,14 +127,12 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 	buf.Reset()
 	defer bufPool.Put(buf)
 
-	if err = node.writeBytes(buf); err != nil {
+	bz, err := node.Encode()
+	if err != nil {
 		return err
 	}
 
-	bytesCopy := make([]byte, buf.Len())
-	copy(bytesCopy, buf.Bytes())
-
-	if err = i.batch.Set(i.tree.ndb.nodeKey(node.hash), bytesCopy); err != nil {
+	if err = i.batch.Set(i.tree.ndb.nodeKey(node.hash), bz); err != nil {
 		return err
 	}
 

--- a/node.go
+++ b/node.go
@@ -21,12 +21,7 @@ import (
 
 var errBufferTooSmall = errors.New("buffer too small")
 
-const (
-	SizeHash = 32
-
-	OverflowVersion = 0x01
-	OverflowSize    = 0x02
-)
+const SizeHash = 32
 
 // Node represents a node in a Tree.
 type Node struct {
@@ -399,9 +394,6 @@ func (node *Node) writeHashBytesRecursively(w io.Writer) (hashCount int64, err e
 // node encoded layout:
 // header: height(1) + stream vbyte (version, size_lo, size_hi, keyLen),
 // body: key + [leftHash(32), rightHash(32)], [value]
-//
-// overflow records if version or size overflows uint32,
-// if true, there's extra 4 bytes to store the high part.
 func (node *Node) maxEncodedSize() int {
 	size := 1 + 1 + 4*4 + len(node.key)
 	if node.isLeaf() {

--- a/nodedb.go
+++ b/nodedb.go
@@ -192,14 +192,12 @@ func (ndb *nodeDB) SaveNode(node *Node) error {
 	}
 
 	// Save node bytes to db.
-	var buf bytes.Buffer
-	buf.Grow(node.encodedSize())
-
-	if err := node.writeBytes(&buf); err != nil {
+	bz, err := node.Encode()
+	if err != nil {
 		return err
 	}
 
-	if err := ndb.batch.Set(ndb.nodeKey(node.hash), buf.Bytes()); err != nil {
+	if err := ndb.batch.Set(ndb.nodeKey(node.hash), bz); err != nil {
 		return err
 	}
 	logger.Debug("BATCH SAVE %X %p\n", node.hash, node)


### PR DESCRIPTION
This is a node storage format change, need to migrate database, but I guess it's ok in light of new node key format, we'll need to migrate anyway, the same technique can be applied to new node key format as well.
The improvement is pretty good, we don't even use the SIMP optimizations, since we don't have that much integers.

Downside:
- don't support version bigger than `math.MaxUint32`.
  - I did a calculation, say block time is 2 second, `(((1<<32)-1) * 2) / 3600/24/365 = 272`, it means it takes 272 years for the version number to overflow `uint32`, we are using 6 seconds block time right now, which makes it even longer.

### Benchmark

```
$ go test -run=^$ -bench="maxEncodedSize|Encode|Decode" -benchmem ./ -count=10
```

Compare with [this version](https://github.com/yihuang/iavl/tree/stream-vbyte-compare) where I adjusted the test cases the same as this PR:
```
name                          old time/op    new time/op    delta
Node_maxEncodedSize-12          7.33ns ± 4%    0.24ns ± 3%  -96.67%  (p=0.000 n=10+9)
Node_Encode/small_integer-12     245ns ± 1%      55ns ± 1%  -77.62%  (p=0.000 n=10+10)
Node_Encode/large_integer-12     245ns ± 2%      55ns ± 0%  -77.64%  (p=0.000 n=10+9)
Node_Decode/small_number-12      169ns ± 1%      65ns ± 2%  -61.73%  (p=0.000 n=10+9)
Node_Decode/large_number-12      170ns ± 1%      65ns ± 1%  -61.92%  (p=0.000 n=10+9)

name                          old alloc/op   new alloc/op   delta
Node_maxEncodedSize-12           0.00B          0.00B          ~     (all equal)
Node_Encode/small_integer-12      160B ± 0%      112B ± 0%  -30.00%  (p=0.000 n=10+10)
Node_Encode/large_integer-12      160B ± 0%      112B ± 0%  -30.00%  (p=0.000 n=10+10)
Node_Decode/small_number-12       256B ± 0%      160B ± 0%  -37.50%  (p=0.000 n=10+10)
Node_Decode/large_number-12       256B ± 0%      160B ± 0%  -37.50%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
Node_maxEncodedSize-12            0.00           0.00          ~     (all equal)
Node_Encode/small_integer-12      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
Node_Encode/large_integer-12      2.00 ± 0%      1.00 ± 0%  -50.00%  (p=0.000 n=10+10)
Node_Decode/small_number-12       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)
Node_Decode/large_number-12       4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)
```