### PR TITLE
skip branch node's key in import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [#646](https://github.com/cosmos/iavl/pull/646) Remove the `orphans` from the storage
 - [#622](https://github.com/cosmos/iavl/pull/622) `export/newExporter()` and `ImmutableTree.Export()` returns error for nil arguements
+- [#]() Skip branch node's key in import/export, the export behavior change is guarded by new option `DisableExportBranchNodeKey` which defaults to `false`, it's only breaking if user switch that option on.
 
 ### API Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - [#646](https://github.com/cosmos/iavl/pull/646) Remove the `orphans` from the storage
 - [#622](https://github.com/cosmos/iavl/pull/622) `export/newExporter()` and `ImmutableTree.Export()` returns error for nil arguements
-- [#]() Skip branch node's key in import/export, the export behavior change is guarded by new option `DisableExportBranchNodeKey` which defaults to `false`, it's only breaking if user switch that option on.
+- [#689](https://github.com/cosmos/iavl/pull/689) Skip branch node's key in import/export, the export behavior change is guarded by new option `DisableExportBranchNodeKey` which defaults to `false`, it's only breaking if user switch that option on.
 
 ### API Changes
 

--- a/export_test.go
+++ b/export_test.go
@@ -13,8 +13,10 @@ import (
 
 // setupExportTreeBasic sets up a basic tree with a handful of
 // create/update/delete operations over a few versions.
-func setupExportTreeBasic(t require.TestingT) *ImmutableTree {
-	tree, err := NewMutableTree(db.NewMemDB(), 0, false)
+func setupExportTreeBasic(t require.TestingT, noBranchNodeKey bool) *ImmutableTree {
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, &Options{
+		DisableExportBranchNodeKey: noBranchNodeKey,
+	}, false)
 	require.NoError(t, err)
 
 	_, err = tree.Set([]byte("x"), []byte{255})
@@ -158,7 +160,7 @@ func setupExportTreeSized(t require.TestingT, treeSize int) *ImmutableTree { //n
 }
 
 func TestExporter(t *testing.T) {
-	tree := setupExportTreeBasic(t)
+	tree := setupExportTreeBasic(t, false)
 
 	expect := []*ExportNode{
 		{Key: []byte("a"), Value: []byte{1}, Version: 1, Height: 0},
@@ -190,8 +192,9 @@ func TestExporter(t *testing.T) {
 
 func TestExporter_Import(t *testing.T) {
 	testcases := map[string]*ImmutableTree{
-		"empty tree": NewImmutableTree(db.NewMemDB(), 0, false),
-		"basic tree": setupExportTreeBasic(t),
+		"empty tree":         NewImmutableTree(db.NewMemDB(), 0, false),
+		"basic tree":         setupExportTreeBasic(t, false),
+		"no branch node key": setupExportTreeBasic(t, true),
 	}
 	if !testing.Short() {
 		testcases["sized tree"] = setupExportTreeSized(t, 4096)

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -156,7 +156,7 @@ func (t *ImmutableTree) Hash() ([]byte, error) {
 // Export returns an iterator that exports tree nodes as ExportNodes. These nodes can be
 // imported with MutableTree.Import() to recreate an identical tree.
 func (t *ImmutableTree) Export() (*Exporter, error) {
-	return newExporter(t)
+	return newExporter(t, !t.ndb.opts.DisableExportBranchNodeKey)
 }
 
 // GetWithIndex returns the index and value of the specified key if it exists, or nil and the next index

--- a/import.go
+++ b/import.go
@@ -28,7 +28,7 @@ type Importer struct {
 	batchSize uint32
 	stack     []*Node
 	// minKeyStack has the same length as stack, it maintains the smallest key in each node's subtree,
-	// branch node always use the smallest key in it's right branch, so we don't have to export the branch node's key.
+	// we use it to derive the smallest key of the right branch for branch nodes, so we don't have to export the branch node's key in snapshot.
 	minKeyStack [][]byte
 }
 

--- a/options.go
+++ b/options.go
@@ -81,6 +81,10 @@ type Options struct {
 
 	// When Stat is not nil, statistical logic needs to be executed
 	Stat *Statistics
+
+	// don't export branch node's key in snapshot, default to false.
+	// see: https://github.com/cosmos/iavl/issues/688
+	DisableExportBranchNodeKey bool
 }
 
 // DefaultOptions returns the default options for IAVL.


### PR DESCRIPTION
Closes: #688

since it can be derived on the fly.

I think should be ok to backport to 0.19, since it's not breaking when the new option is `false`.