### PR TITLE
perf: Remove SaveNode cache update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Improvements
 
 - [#703](https://github.com/cosmos/iavl/pull/703) New APIs `NewCompressExporter`/`NewCompressImporter` to support more compact snapshot format.
+- [#728](https://github.com/cosmos/iavl/pull/728) Remove automatically adding internal IAVL nodes into the LRU cache.
 
 ### Breaking Changes
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -199,7 +199,6 @@ func (ndb *nodeDB) SaveNode(node *Node) error {
 	}
 
 	logger.Debug("BATCH SAVE %+v\n", node)
-	ndb.nodeCache.Add(node)
 	return nil
 }
 


### PR DESCRIPTION
Remove NodeDB.SaveNode from updating the LRU cache. (FastNodes still update the LRU cache on write)

SaveNode touching the cache adds many extra nodes into this, that are likely unused given the fast nodes. They would only come in handy for IBC proof queries. 

But caching every write is an ineffective strategy for that, instead you would rather employ strategies that "watch" for applicable key ranges.

SaveNodes adds some overhead for InitGenesis logic with the extra heap allocations, which this then speeds up.