### PR TITLE
feat: refactor the node struct

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -21,7 +21,7 @@ type KVPairReceiver func(pair *KVPair) error
 //
 // The algorithm don't run in constant memory strictly, but it tried the best the only
 // keep minimal intermediate states in memory.
-func (ndb *nodeDB) extractStateChanges(prevVersion int64, prevRoot *NodeKey, root *NodeKey, receiver KVPairReceiver) error {
+func (ndb *nodeDB) extractStateChanges(prevVersion int64, prevRoot, root []byte, receiver KVPairReceiver) error {
 	curIter, err := NewNodeIterator(root, ndb)
 	if err != nil {
 		return err

--- a/import.go
+++ b/import.go
@@ -74,7 +74,7 @@ func (i *Importer) writeNode(node *Node) error {
 	bytesCopy := make([]byte, buf.Len())
 	copy(bytesCopy, buf.Bytes())
 
-	if err := i.batch.Set(i.tree.ndb.nodeKey(node.nodeKey), bytesCopy); err != nil {
+	if err := i.batch.Set(i.tree.ndb.nodeKey(node.GetKey()), bytesCopy); err != nil {
 		return err
 	}
 
@@ -135,8 +135,8 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 	} else if stackSize >= 2 && i.stack[stackSize-1].subtreeHeight < node.subtreeHeight && i.stack[stackSize-2].subtreeHeight < node.subtreeHeight {
 		node.leftNode = i.stack[stackSize-2]
 		node.rightNode = i.stack[stackSize-1]
-		node.leftNodeKey = node.leftNode.nodeKey
-		node.rightNodeKey = node.rightNode.nodeKey
+		node.leftNodeKey = node.leftNode.GetKey()
+		node.rightNodeKey = node.rightNode.GetKey()
 		node.size = node.leftNode.size + node.rightNode.size
 		// Update the stack now.
 		if err := i.writeNode(i.stack[stackSize-2]); err != nil {
@@ -169,7 +169,7 @@ func (i *Importer) Commit() error {
 
 	switch len(i.stack) {
 	case 0:
-		if err := i.batch.Set(i.tree.ndb.nodeKey(&NodeKey{version: i.version, nonce: 1}), []byte{}); err != nil {
+		if err := i.batch.Set(i.tree.ndb.nodeKey(GetRootKey(i.version)), []byte{}); err != nil {
 			return err
 		}
 	case 1:
@@ -178,7 +178,7 @@ func (i *Importer) Commit() error {
 			return err
 		}
 		if i.stack[0].nodeKey.version < i.version { // it means there is no update in the given version
-			if err := i.batch.Set(i.tree.ndb.nodeKey(&NodeKey{version: i.version, nonce: 1}), i.tree.ndb.nodeKey(i.stack[0].nodeKey)); err != nil {
+			if err := i.batch.Set(i.tree.ndb.nodeKey(GetRootKey(i.version)), i.tree.ndb.nodeKey(i.stack[0].GetKey())); err != nil {
 				return err
 			}
 		}

--- a/iterator.go
+++ b/iterator.go
@@ -268,7 +268,7 @@ type NodeIterator struct {
 }
 
 // NewNodeIterator returns a new NodeIterator to traverse the tree of the root node.
-func NewNodeIterator(rootKey *NodeKey, ndb *nodeDB) (*NodeIterator, error) {
+func NewNodeIterator(rootKey []byte, ndb *nodeDB) (*NodeIterator, error) {
 	if rootKey == nil {
 		return &NodeIterator{
 			nodesToVisit: []*Node{},

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -344,7 +344,7 @@ func TestNodeIterator_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	// check if the iterating count is same with the entire node count of the tree
-	itr, err := NewNodeIterator(tree.root.nodeKey, tree.ndb)
+	itr, err := NewNodeIterator(tree.root.GetKey(), tree.ndb)
 	require.NoError(t, err)
 	nodeCount := 0
 	for ; itr.Valid(); itr.Next(false) {
@@ -353,7 +353,7 @@ func TestNodeIterator_Success(t *testing.T) {
 	require.Equal(t, int64(nodeCount), tree.Size()*2-1)
 
 	// check if the skipped node count is right
-	itr, err = NewNodeIterator(tree.root.nodeKey, tree.ndb)
+	itr, err = NewNodeIterator(tree.root.GetKey(), tree.ndb)
 	require.NoError(t, err)
 	updateCount := 0
 	skipCount := 0

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -973,10 +973,10 @@ func (tree *MutableTree) balance(node *Node) (newSelf *Node, err error) {
 func (tree *MutableTree) saveNewNodes(version int64) error {
 	nonce := int32(0)
 	newNodes := make([]*Node, 0)
-	var recursiveAssignKey func(*Node) (*NodeKey, error)
-	recursiveAssignKey = func(node *Node) (*NodeKey, error) {
+	var recursiveAssignKey func(*Node) ([]byte, error)
+	recursiveAssignKey = func(node *Node) ([]byte, error) {
 		if node.nodeKey != nil {
-			return node.nodeKey, nil
+			return node.nodeKey.GetKey(), nil
 		}
 		nonce++
 		node.nodeKey = &NodeKey{
@@ -1002,7 +1002,7 @@ func (tree *MutableTree) saveNewNodes(version int64) error {
 		if err != nil {
 			return nil, err
 		}
-		return node.nodeKey, nil
+		return node.nodeKey.GetKey(), nil
 	}
 
 	if _, err := recursiveAssignKey(tree.root); err != nil {

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -807,7 +807,7 @@ func TestUpgradeStorageToFast_DbErrorConstructor_Failure(t *testing.T) {
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(1)
-	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(1))
+	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(GetRootKey(1)))
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	expectedError := errors.New("some db error")
@@ -832,7 +832,7 @@ func TestUpgradeStorageToFast_DbErrorEnableFastStorage_Failure(t *testing.T) {
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(1)
-	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(1))
+	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(GetRootKey(1)))
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	expectedError := errors.New("some db error")
@@ -883,7 +883,7 @@ func TestFastStorageReUpgradeProtection_NoForceUpgrade_Success(t *testing.T) {
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(1)
-	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(1))
+	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(GetRootKey(1)))
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	batchMock := mock.NewMockBatch(ctrl)
@@ -946,7 +946,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(1)
-	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(latestTreeVersion))
+	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(GetRootKey(latestTreeVersion)))
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	fastNodeKeyToDelete := []byte("some_key")
@@ -1447,7 +1447,7 @@ func TestMutableTree_InitialVersion_FirstVersion(t *testing.T) {
 	_, version, err := tree.SaveVersion()
 	require.NoError(t, err)
 	require.Equal(t, initialVersion, version)
-	rootKey := &NodeKey{version: version, nonce: 1}
+	rootKey := GetRootKey(version)
 	// the nodes created at the first version are not assigned with the `InitialVersion`
 	node, err := tree.ndb.GetNode(rootKey)
 	require.NoError(t, err)
@@ -1459,7 +1459,7 @@ func TestMutableTree_InitialVersion_FirstVersion(t *testing.T) {
 	_, version, err = tree.SaveVersion()
 	require.NoError(t, err)
 	require.Equal(t, initialVersion+1, version)
-	rootKey = &NodeKey{version: version, nonce: 1}
+	rootKey = GetRootKey(version)
 	// the following versions behaves normally
 	node, err = tree.ndb.GetNode(rootKey)
 	require.NoError(t, err)

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -16,11 +16,13 @@ import (
 
 func BenchmarkNodeKey(b *testing.B) {
 	ndb := &nodeDB{}
+
 	for i := 0; i < b.N; i++ {
-		ndb.nodeKey(&NodeKey{
+		nk := &NodeKey{
 			version: int64(i),
 			nonce:   int32(i),
-		})
+		}
+		ndb.nodeKey(nk.GetKey())
 	}
 }
 
@@ -110,7 +112,7 @@ func TestSetStorageVersion_DBFailure_OldKept(t *testing.T) {
 
 	// rIterMock is used to get the latest version from disk. We are mocking that rIterMock returns latestTreeVersion from disk
 	rIterMock.EXPECT().Valid().Return(true).Times(1)
-	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(expectedFastCacheVersion)).Times(1)
+	rIterMock.EXPECT().Key().Return(nodeKeyFormat.Key(GetRootKey(int64(expectedFastCacheVersion)))).Times(1)
 	rIterMock.EXPECT().Close().Return(nil).Times(1)
 
 	dbMock.EXPECT().ReverseIterator(gomock.Any(), gomock.Any()).Return(rIterMock, nil).Times(1)
@@ -277,7 +279,7 @@ func TestTraverseNodes(t *testing.T) {
 
 	count := 0
 	err = tree.ndb.traverseNodes(func(node *Node) error {
-		actualNode, err := tree.ndb.GetNode(node.nodeKey)
+		actualNode, err := tree.ndb.GetNode(node.GetKey())
 		if err != nil {
 			return err
 		}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1576,7 +1576,7 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 	}
 
 	for _, n := range removedNodes {
-		has, _ := tree.ndb.Has(n.nodeKey)
+		has, _ := tree.ndb.Has(n.GetKey())
 		require.False(has, "LoadVersionForOverwriting should remove useless nodes")
 	}
 
@@ -1631,7 +1631,7 @@ func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	err = tree.LoadVersionForOverwriting(1)
 	require.NoError(err)
 	for _, n := range removedNodes {
-		has, err := tree.ndb.Has(n.nodeKey)
+		has, err := tree.ndb.Has(n.GetKey())
 		require.NoError(err)
 		require.False(has, "LoadVersionForOverwriting should remove useless nodes")
 	}


### PR DESCRIPTION
ref: #747 

It refactored the node struct as discussed in #747.
`leftNodeKey` and `rightNodeKey` types are changed from `*NodeKey` to `[]byte` to allow the reference of the old key format (node hash).