### PR TITLE
perf: reduce use of unsafe functions, and make them safer

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: '1.20' # The Go version to download (if necessary) and use.
       - name: run benchmarks
         run: make bench

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.19' # The Go version to download (if necessary) and use.
+          go-version: '1.20' # The Go version to download (if necessary) and use.
 
         # Some tests, notably TestRandomOperations, are extremely slow in CI
         # with the race detector enabled, so we use -short when -race is

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -1,8 +1,9 @@
 package benchmarks
 
 import (
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	mrand "math/rand"
 	"os"
 	"runtime"
 	"strings"
@@ -21,7 +22,7 @@ func randBytes(length int) []byte {
 	key := make([]byte, length)
 	// math.rand.Read always returns err=nil
 	// we do not need cryptographic randomness for this test:
-	rand.Read(key)
+	rand.Read(key) //nolint:errcheck
 	return key
 }
 
@@ -78,7 +79,7 @@ func runKnownQueriesFast(b *testing.B, t *iavl.MutableTree, keys [][]byte) {
 	require.True(b, isFastCacheEnabled)
 	l := int32(len(keys))
 	for i := 0; i < b.N; i++ {
-		q := keys[rand.Int31n(l)]
+		q := keys[mrand.Int31n(l)]
 		_, err := t.Get(q)
 		require.NoError(b, err)
 	}
@@ -120,7 +121,7 @@ func runKnownQueriesSlow(b *testing.B, t *iavl.MutableTree, keys [][]byte) {
 	b.StartTimer()
 	l := int32(len(keys))
 	for i := 0; i < b.N; i++ {
-		q := keys[rand.Int31n(l)]
+		q := keys[mrand.Int31n(l)]
 		index, value, err := itree.GetWithIndex(q)
 		require.NoError(b, err)
 		require.True(b, index >= 0, "the index must not be negative")
@@ -177,7 +178,7 @@ func iterate(b *testing.B, itr db.Iterator, expectedSize int) {
 func runUpdate(b *testing.B, t *iavl.MutableTree, dataLen, blockSize int, keys [][]byte) *iavl.MutableTree {
 	l := int32(len(keys))
 	for i := 1; i <= b.N; i++ {
-		key := keys[rand.Int31n(l)]
+		key := keys[mrand.Int31n(l)]
 		_, err := t.Set(key, randBytes(dataLen))
 		require.NoError(b, err)
 		if i%blockSize == 0 {
@@ -217,7 +218,7 @@ func runBlock(b *testing.B, t *iavl.MutableTree, keyLen, dataLen, blockSize int,
 			// 50% insert, 50% update
 			var key []byte
 			if i%2 == 0 {
-				key = keys[rand.Int31n(l)]
+				key = keys[mrand.Int31n(l)]
 			} else {
 				key = randBytes(keyLen)
 			}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -61,8 +61,7 @@ func New(maxElementCount int) Cache {
 }
 
 func (c *lruCache) Add(node Node) Node {
-	keyStr := ibytes.UnsafeBytesToStr(node.GetKey())
-	if e, exists := c.dict[keyStr]; exists {
+	if e, exists := c.dict[string(node.GetKey())]; exists {
 		c.ll.MoveToFront(e)
 		old := e.Value
 		e.Value = node
@@ -70,7 +69,7 @@ func (c *lruCache) Add(node Node) Node {
 	}
 
 	elem := c.ll.PushFront(node)
-	c.dict[keyStr] = elem
+	c.dict[string(node.GetKey())] = elem
 
 	if c.ll.Len() > c.maxElementCount {
 		oldest := c.ll.Back()
@@ -80,7 +79,7 @@ func (c *lruCache) Add(node Node) Node {
 }
 
 func (c *lruCache) Get(key []byte) Node {
-	if ele, hit := c.dict[ibytes.UnsafeBytesToStr(key)]; hit {
+	if ele, hit := c.dict[string(key)]; hit {
 		c.ll.MoveToFront(ele)
 		return ele.Value.(Node)
 	}
@@ -88,7 +87,7 @@ func (c *lruCache) Get(key []byte) Node {
 }
 
 func (c *lruCache) Has(key []byte) bool {
-	_, exists := c.dict[ibytes.UnsafeBytesToStr(key)]
+	_, exists := c.dict[string(key)]
 	return exists
 }
 
@@ -97,7 +96,7 @@ func (c *lruCache) Len() int {
 }
 
 func (c *lruCache) Remove(key []byte) Node {
-	if elem, exists := c.dict[ibytes.UnsafeBytesToStr(key)]; exists {
+	if elem, exists := c.dict[string(key)]; exists {
 		return c.remove(elem)
 	}
 	return nil

--- a/cmd/iaviewer/main.go
+++ b/cmd/iaviewer/main.go
@@ -14,7 +14,6 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 
 	"github.com/cosmos/iavl"
-	ibytes "github.com/cosmos/iavl/internal/bytes"
 )
 
 // TODO: make this configurable?
@@ -102,8 +101,8 @@ func PrintDBStats(db dbm.DB) {
 
 	defer itr.Close()
 	for ; itr.Valid(); itr.Next() {
-		key := ibytes.UnsafeBytesToStr(itr.Key()[:1])
-		prefix[key]++
+		key := itr.Key()[:1]
+		prefix[string(key)]++
 		count++
 	}
 	if err := itr.Error(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cosmos/iavl
 
-go 1.19
+go 1.20
 
 require (
 	cosmossdk.io/log v1.1.0

--- a/internal/bytes/string.go
+++ b/internal/bytes/string.go
@@ -1,20 +1,16 @@
 package common
 
 import (
-	"reflect"
 	"unsafe"
 )
 
 // UnsafeStrToBytes uses unsafe to convert string into byte array. Returned bytes
 // must not be altered after this function is called as it will cause a segmentation fault.
 func UnsafeStrToBytes(s string) []byte {
-	var buf []byte
-	sHdr := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bufHdr := (*reflect.SliceHeader)(unsafe.Pointer(&buf))
-	bufHdr.Data = sHdr.Data
-	bufHdr.Cap = sHdr.Len
-	bufHdr.Len = sHdr.Len
-	return buf
+	if len(s) == 0 {
+		return nil
+	}
+	return unsafe.Slice(unsafe.StringData(s), len(s))
 }
 
 // UnsafeBytesToStr is meant to make a zero allocation conversion
@@ -22,5 +18,8 @@ func UnsafeStrToBytes(s string) []byte {
 // to be used generally, but for a specific pattern to delete keys
 // from a map.
 func UnsafeBytesToStr(b []byte) string {
-	return *(*string)(unsafe.Pointer(&b))
+	if len(b) == 0 {
+		return ""
+	}
+	return unsafe.String(&b[0], len(b))
 }

--- a/internal/rand/random_test.go
+++ b/internal/rand/random_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	mrand "math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,10 +25,6 @@ func TestRandBytes(t *testing.T) {
 // We do this by ensuring that outputs are deterministic.
 func TestDeterminism(t *testing.T) {
 	var firstOutput string
-
-	// Set math/rand's seed for the sake of debugging this test.
-	// (It isn't strictly necessary).
-	mrand.Seed(1)
 
 	for i := 0; i < 100; i++ {
 		output := testThemAll()

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -138,7 +138,7 @@ func (tree *MutableTree) Get(key []byte) ([]byte, error) {
 	}
 
 	if !tree.skipFastStorageUpgrade {
-		if fastNode, ok := tree.unsavedFastNodeAdditions[ibytes.UnsafeBytesToStr(key)]; ok {
+		if fastNode, ok := tree.unsavedFastNodeAdditions[string(key)]; ok {
 			return fastNode.GetValue(), nil
 		}
 		// check if node was deleted
@@ -770,9 +770,8 @@ func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
 }
 
 func (tree *MutableTree) addUnsavedAddition(key []byte, node *fastnode.Node) {
-	skey := ibytes.UnsafeBytesToStr(key)
-	delete(tree.unsavedFastNodeRemovals, skey)
-	tree.unsavedFastNodeAdditions[skey] = node
+	delete(tree.unsavedFastNodeRemovals, ibytes.UnsafeBytesToStr(key))
+	tree.unsavedFastNodeAdditions[string(key)] = node
 }
 
 func (tree *MutableTree) saveFastNodeAdditions(batchCommmit bool) error {

--- a/nodedb.go
+++ b/nodedb.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/cosmos/iavl/cache"
 	"github.com/cosmos/iavl/fastnode"
-	ibytes "github.com/cosmos/iavl/internal/bytes"
 	"github.com/cosmos/iavl/keyformat"
 )
 
@@ -80,7 +79,7 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options, lg log.Logger) *nodeDB {
 		opts = &o
 	}
 
-	storeVersion, err := db.Get(metadataKeyFormat.Key(ibytes.UnsafeStrToBytes(storageVersionKey)))
+	storeVersion, err := db.Get(metadataKeyFormat.Key([]byte(storageVersionKey)))
 
 	if err != nil || storeVersion == nil {
 		storeVersion = []byte(defaultStorageVersionValue)

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -2,7 +2,8 @@ package iavl
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
+	mrand "math/rand"
 	"sort"
 	"testing"
 
@@ -129,7 +130,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 	b.Run("fast", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			caseIdx := rand.Intn(len(cases))
+			caseIdx := mrand.Intn(len(cases))
 			tc := cases[caseIdx]
 
 			tree, allkeys, err := BuildTree(tc.size, 100000)
@@ -149,7 +150,7 @@ func BenchmarkGetNonMembership(b *testing.B) {
 	b.Run("regular", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			b.StopTimer()
-			caseIdx := rand.Intn(len(cases))
+			caseIdx := mrand.Intn(len(cases))
 			tc := cases[caseIdx]
 
 			tree, allkeys, err := BuildTree(tc.size, 100000)
@@ -184,7 +185,7 @@ func GetKey(allkeys [][]byte, loc Where) []byte {
 		return allkeys[len(allkeys)-1]
 	}
 	// select a random index between 1 and allkeys-2
-	idx := rand.Int()%(len(allkeys)-2) + 1
+	idx := mrand.Int()%(len(allkeys)-2) + 1
 	return allkeys[idx]
 }
 
@@ -216,7 +217,7 @@ func BuildTree(size int, cacheSize int) (itree *MutableTree, keys [][]byte, err 
 	for i := 0; i < size; i++ {
 		key := make([]byte, 4)
 		// create random 4 byte key
-		rand.Read(key)
+		rand.Read(key) //nolint:errcheck
 		value := "value_for_key:" + string(key)
 		_, err = tree.Set(key, []byte(value))
 		if err != nil {

--- a/tree_dotgraph.go
+++ b/tree_dotgraph.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"text/template"
 
-	ibytes "github.com/cosmos/iavl/internal/bytes"
 	"github.com/emicklei/dot"
 )
 
@@ -61,12 +60,12 @@ func WriteDOTGraph(w io.Writer, tree *ImmutableTree, paths []PathToLeaf) {
 		}
 		shortHash := graphNode.Hash[:7]
 
-		graphNode.Label = mkLabel(ibytes.UnsafeBytesToStr(node.key), 16, "sans-serif")
+		graphNode.Label = mkLabel(string(node.key), 16, "sans-serif")
 		graphNode.Label += mkLabel(shortHash, 10, "monospace")
 		graphNode.Label += mkLabel(fmt.Sprintf("nodeKey=%v", node.nodeKey), 10, "monospace")
 
 		if node.value != nil {
-			graphNode.Label += mkLabel(ibytes.UnsafeBytesToStr(node.value), 10, "sans-serif")
+			graphNode.Label += mkLabel(string(node.value), 10, "sans-serif")
 		}
 
 		if node.subtreeHeight == 0 {


### PR DESCRIPTION
The safer functions require Go 1.20. Let me know if that's not acceptable.

CC @odeke-em 