### PR TITLE
docs: add cosmos sdk compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-# IAVL+ Tree 
-
+# IAVL+ Tree
 
 [![version](https://img.shields.io/github/tag/cosmos/iavl.svg)](https://github.com/cosmos/iavl/releases/latest)
 [![license](https://img.shields.io/github/license/cosmos/iavl.svg)](https://github.com/cosmos/iavl/blob/master/LICENSE)
@@ -8,7 +7,7 @@
 ![Test](https://github.com/cosmos/iavl/workflows/Test/badge.svg?branch=master)
 [![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/AzefAFd)
 
-**Note: Requires Go 1.18+**
+Note: **Requires Go 1.18+**
 
 A versioned, snapshottable (immutable) AVL+ tree for persistent data.
 
@@ -21,3 +20,12 @@ Nodes of this tree are immutable and indexed by their hash. Thus any node serves
 In an AVL tree, the heights of the two child subtrees of any node differ by at most one. Whenever this condition is violated upon an update, the tree is rebalanced by creating O(log(n)) new nodes that point to unmodified nodes of the old tree. In the original AVL algorithm, inner nodes can also hold key-value pairs. The AVL+ algorithm (note the plus) modifies the AVL algorithm to keep all values on leaf nodes, while only using branch-nodes to store keys. This simplifies the algorithm while keeping the merkle hash trail short.
 
 In Ethereum, the analog is [Patricia tries](http://en.wikipedia.org/wiki/Radix_tree). There are tradeoffs. Keys do not need to be hashed prior to insertion in IAVL+ trees, so this provides faster iteration in the key space which may benefit some applications. The logic is simpler to implement, requiring only two types of nodes -- inner nodes and leaf nodes. On the other hand, while IAVL+ trees provide a deterministic merkle root hash, it depends on the order of transactions. In practice this shouldn't be a problem, since you can efficiently encode the tree structure when serializing the tree contents.
+
+## IAVL x Cosmos SDK
+
+| IAVL                                                           | DB Interface                                             | Cosmos SDK       |
+| -------------------------------------------------------------- | -------------------------------------------------------- | ---------------- |
+| [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | [`tm-db`](https://github.com/tendermint/tm-db)           | v0.45.x, v0.46.x |
+| [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | [`cometbft-db`](https://github.com/cometbft/cometbft-db) | v0.47.x          |
+| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |
+| [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,6 +1,6 @@
 # IAVL x Cosmos SDK
 
-| IAVL                                                           | DB Interfaces                                            | Cosmos SDK       |
+| IAVL                                                           | DB Interface                                             | Cosmos SDK       |
 | -------------------------------------------------------------- | -------------------------------------------------------- | ---------------- |
 | [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | [`tm-db`](https://github.com/tendermint/tm-db)           | v0.45.x, v0.46.x |
 | [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | [`cometbft-db`](https://github.com/cometbft/cometbft-db) | v0.47.x          |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,0 +1,15 @@
+# IAVL x Cosmos SDK
+
+| IAVL                                                           | Cosmos SDK       |
+| -------------------------------------------------------------- | ---------------- |
+| [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | v0.45.x, v0.46.x |
+| [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | v0.47.x          |
+| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | v0.48.x          |
+| [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | -                |
+
+## Overview
+
+- v0.19.x of IAVL uses [`tm-db`](https://github.com/tendermint/tm-db)
+- v0.20.x of IAVL uses [`cometbft-db`](https://github.com/cometbft/cometbft-db)
+- v0.21.x of IAVL uses [`cosmos-db`](https://github.com/cosmos/cosmos-db)
+- v1.x.x of IAVL uses [`cosmos-db`](https://github.com/cosmos/cosmos-db)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,15 +1,8 @@
 # IAVL x Cosmos SDK
 
-| IAVL                                                           | Cosmos SDK       |
-| -------------------------------------------------------------- | ---------------- |
-| [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | v0.45.x, v0.46.x |
-| [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | v0.47.x          |
-| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | -                |
-| [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | -                |
-
-## DB Overview
-
-- v0.19.x of IAVL uses [`tm-db`](https://github.com/tendermint/tm-db)
-- v0.20.x of IAVL uses [`cometbft-db`](https://github.com/cometbft/cometbft-db)
-- v0.21.x of IAVL uses [`cosmos-db`](https://github.com/cosmos/cosmos-db)
-- v1.x.x of IAVL uses [`cosmos-db`](https://github.com/cosmos/cosmos-db)
+| IAVL                                                           | DB Interfaces                                            | Cosmos SDK       |
+| -------------------------------------------------------------- | -------------------------------------------------------- | ---------------- |
+| [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | [`tm-db`](https://github.com/tendermint/tm-db)           | v0.45.x, v0.46.x |
+| [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | [`cometbft-db`](https://github.com/cometbft/cometbft-db) | v0.47.x          |
+| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |
+| [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -7,7 +7,7 @@
 | [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | v0.48.x          |
 | [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | -                |
 
-## Overview
+## DB Overview
 
 - v0.19.x of IAVL uses [`tm-db`](https://github.com/tendermint/tm-db)
 - v0.20.x of IAVL uses [`cometbft-db`](https://github.com/cometbft/cometbft-db)

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,7 +4,7 @@
 | -------------------------------------------------------------- | ---------------- |
 | [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | v0.45.x, v0.46.x |
 | [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | v0.47.x          |
-| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | v0.48.x          |
+| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | -                |
 | [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | -                |
 
 ## DB Overview

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -1,8 +1,0 @@
-# IAVL x Cosmos SDK
-
-| IAVL                                                           | DB Interface                                             | Cosmos SDK       |
-| -------------------------------------------------------------- | -------------------------------------------------------- | ---------------- |
-| [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | [`tm-db`](https://github.com/tendermint/tm-db)           | v0.45.x, v0.46.x |
-| [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | [`cometbft-db`](https://github.com/cometbft/cometbft-db) | v0.47.x          |
-| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |
-| [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |


### PR DESCRIPTION
I have every time to lookup which versions are compatible with which IAVL version and tm-db/cometbft-db/cosmos-db version.
This adds a table, so we do not need to look it up all the time.

Feel free to close it if we do not need to add this to the repo, at least now I still have this PR to refer myself to.