### PR TITLE
feat: add `WorkingVersion` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [#729](https://github.com/cosmos/iavl/pull/729) Speedup Genesis writes for IAVL, by writing in small batches.
 - [#726](https://github.com/cosmos/iavl/pull/726) Make `KVPair` and `ChangeSet` serializable with protobuf.
 - [#718](https://github.com/cosmos/iavl/pull/718) Fix `traverseNodes` unexpected behaviour
-- [#]() Add `WorkingVersion()int64` API.
+- [#770](https://github.com/cosmos/iavl/pull/770) Add `WorkingVersion()int64` API.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#729](https://github.com/cosmos/iavl/pull/729) Speedup Genesis writes for IAVL, by writing in small batches.
 - [#726](https://github.com/cosmos/iavl/pull/726) Make `KVPair` and `ChangeSet` serializable with protobuf.
 - [#718](https://github.com/cosmos/iavl/pull/718) Fix `traverseNodes` unexpected behaviour
+- [#]() Add `WorkingVersion()int64` API.
 
 ### Breaking Changes
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -113,6 +113,14 @@ func (tree *MutableTree) WorkingHash() ([]byte, error) {
 	return tree.ImmutableTree.Hash()
 }
 
+func (tree *MutableTree) WorkingVersion() int64 {
+	version := tree.version + 1
+	if version == 1 && tree.ndb.opts.InitialVersion > 0 {
+		version = int64(tree.ndb.opts.InitialVersion)
+	}
+	return version
+}
+
 // String returns a string representation of the tree.
 func (tree *MutableTree) String() (string, error) {
 	return tree.ndb.String()
@@ -663,11 +671,8 @@ func (tree *MutableTree) GetVersioned(key []byte, version int64) ([]byte, error)
 // SaveVersion saves a new tree version to disk, based on the current state of
 // the tree. Returns the hash and new version number.
 func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
-	version := tree.version + 1
-	isGenesis := (version == 1)
-	if version == 1 && tree.ndb.opts.InitialVersion > 0 {
-		version = int64(tree.ndb.opts.InitialVersion)
-	}
+	isGenesis := (tree.version == 0)
+	version := tree.WorkingVersion()
 
 	if tree.VersionExists(version) {
 		// If the version already exists, return an error as we're attempting to overwrite.


### PR DESCRIPTION
I think the optimistic execution and async commit in sdk will need this together with the `WorkingHash` API.

hide the initial version logic inside.

useful in [async commit](https://github.com/cosmos/cosmos-sdk/pull/16175), will be useful in optimistic execution.