### PR TITLE
Add BatchWithFlusher to iavl tree

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -16,10 +16,13 @@ type BatchWithFlusher struct {
 var _ dbm.Batch = &BatchWithFlusher{}
 
 // Ethereum has found that commit of 100KB is optimal, ref ethereum/go-ethereum#15115
-// var defaultFlushThreshold = 100000
+var defaultFlushThreshold = 100000
 
 // NewBatchWithFlusher returns new BatchWithFlusher wrapping the passed in batch
 func NewBatchWithFlusher(db dbm.DB, flushThreshold int) *BatchWithFlusher {
+	if flushThreshold <= 0 {
+		panic("flushThreshold can't be zero or negative")
+	}
 	return &BatchWithFlusher{
 		db:             db,
 		batch:          db.NewBatchWithSize(flushThreshold),

--- a/batch.go
+++ b/batch.go
@@ -16,7 +16,7 @@ type BatchWithFlusher struct {
 var _ dbm.Batch = &BatchWithFlusher{}
 
 // Ethereum has found that commit of 100KB is optimal, ref ethereum/go-ethereum#15115
-var defaultFlushThreshold = 100000
+var DefaultFlushThreshold = 100000
 
 // NewBatchWithFlusher returns new BatchWithFlusher wrapping the passed in batch
 func NewBatchWithFlusher(db dbm.DB, flushThreshold int) *BatchWithFlusher {

--- a/benchmarks/bench_test.go
+++ b/benchmarks/bench_test.go
@@ -27,7 +27,7 @@ func randBytes(length int) []byte {
 }
 
 func prepareTree(b *testing.B, db db.DB, size, keyLen, dataLen int) (*iavl.MutableTree, [][]byte) {
-	t, err := iavl.NewMutableTreeWithOpts(db, size, nil, false, log.NewNopLogger())
+	t, err := iavl.NewMutableTreeWithOpts(db, size, nil, false, log.NewNopLogger(), iavl.DefaultFlushThreshold)
 	require.NoError(b, err)
 	keys := make([][]byte, size)
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -38,7 +38,8 @@ func NewImmutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastS
 	return &ImmutableTree{
 		logger: lg,
 		// NodeDB-backed Tree.
-		ndb:                    newNodeDB(db, cacheSize, opts, lg),
+		// flushthreshold is 0 since there's no batch commit action.
+		ndb:                    newNodeDB(db, cacheSize, opts, lg, 0),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
 	}
 }

--- a/import.go
+++ b/import.go
@@ -48,7 +48,7 @@ func newImporter(tree *MutableTree, version int64) (*Importer, error) {
 	return &Importer{
 		tree:    tree,
 		version: version,
-		batch:   tree.ndb.db.NewBatch(),
+		batch:   NewBatch(tree.ndb.db, tree.ndb.flushThreshold),
 		stack:   make([]*Node, 0, 8),
 		nonces:  make([]int32, version+1),
 	}, nil
@@ -84,7 +84,7 @@ func (i *Importer) writeNode(node *Node) error {
 			return err
 		}
 		i.batch.Close()
-		i.batch = i.tree.ndb.db.NewBatch()
+		i.batch = NewBatch(i.tree.ndb.db, i.tree.ndb.flushThreshold)
 		i.batchSize = 0
 	}
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -369,7 +369,7 @@ func TestNodeIterator_Success(t *testing.T) {
 }
 
 func TestNodeIterator_WithEmptyRoot(t *testing.T) {
-	itr, err := NewNodeIterator(nil, newNodeDB(dbm.NewMemDB(), 0, nil, log.NewNopLogger()))
+	itr, err := NewNodeIterator(nil, newNodeDB(dbm.NewMemDB(), 0, nil, log.NewNopLogger(), 0))
 	require.NoError(t, err)
 	require.False(t, itr.Valid())
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -46,12 +46,12 @@ type MutableTree struct {
 
 // NewMutableTree returns a new tree with the specified cache size and datastore.
 func NewMutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, lg log.Logger) (*MutableTree, error) {
-	return NewMutableTreeWithOpts(db, cacheSize, nil, skipFastStorageUpgrade, lg)
+	return NewMutableTreeWithOpts(db, cacheSize, nil, skipFastStorageUpgrade, lg, DefaultFlushThreshold)
 }
 
 // NewMutableTreeWithOpts returns a new tree with the specified options.
-func NewMutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastStorageUpgrade bool, lg log.Logger) (*MutableTree, error) {
-	ndb := newNodeDB(db, cacheSize, opts, lg)
+func NewMutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastStorageUpgrade bool, lg log.Logger, flushThreshold int) (*MutableTree, error) {
+	ndb := newNodeDB(db, cacheSize, opts, lg, flushThreshold)
 	head := &ImmutableTree{ndb: ndb, skipFastStorageUpgrade: skipFastStorageUpgrade}
 
 	return &MutableTree{

--- a/proof_iavl_test.go
+++ b/proof_iavl_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestProofOp(t *testing.T) {
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger())
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger(), DefaultFlushThreshold)
 	require.NoError(t, err)
 	keys := []byte{0x0a, 0x11, 0x2e, 0x32, 0x50, 0x72, 0x99, 0xa1, 0xe4, 0xf7} // 10 total.
 	for _, ikey := range keys {

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -43,7 +43,7 @@ func b2i(bz []byte) int {
 
 // Construct a MutableTree
 func getTestTree(cacheSize int) (*MutableTree, error) {
-	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false, log.NewNopLogger())
+	return NewMutableTreeWithOpts(db.NewMemDB(), cacheSize, nil, false, log.NewNopLogger(), DefaultFlushThreshold)
 }
 
 // Convenience for a new node

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -80,7 +80,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 		if !(r.Float64() < cacheChance) {
 			cacheSize = 0
 		}
-		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options, false, log.NewNopLogger())
+		tree, err = NewMutableTreeWithOpts(levelDB, cacheSize, options, false, log.NewNopLogger(), DefaultFlushThreshold)
 		require.NoError(t, err)
 		version, err = tree.Load()
 		require.NoError(t, err)

--- a/tree_test.go
+++ b/tree_test.go
@@ -1535,7 +1535,7 @@ func BenchmarkTreeLoadAndDelete(b *testing.B) {
 func TestLoadVersionForOverwritingCase2(t *testing.T) {
 	require := require.New(t)
 
-	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger())
+	tree, _ := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger(), DefaultFlushThreshold)
 
 	for i := byte(0); i < 20; i++ {
 		tree.Set([]byte{i}, []byte{i})
@@ -1597,7 +1597,7 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 func TestLoadVersionForOverwritingCase3(t *testing.T) {
 	require := require.New(t)
 
-	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger())
+	tree, err := NewMutableTreeWithOpts(db.NewMemDB(), 0, nil, false, log.NewNopLogger(), DefaultFlushThreshold)
 	require.NoError(err)
 
 	for i := byte(0); i < 20; i++ {
@@ -1856,7 +1856,7 @@ func TestNodeCacheStatisic(t *testing.T) {
 			opts := &Options{Stat: stat}
 			db, err := db.NewDB("test", db.MemDBBackend, "")
 			require.NoError(t, err)
-			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts, false, log.NewNopLogger())
+			mt, err := NewMutableTreeWithOpts(db, tc.cacheSize, opts, false, log.NewNopLogger(), DefaultFlushThreshold)
 			require.NoError(t, err)
 
 			for i := 0; i < numKeyVals; i++ {


### PR DESCRIPTION
Closes #619 

* This Pr allow iavl tree to use BatchWithFlusher to limit size of commit to db. By including flushThreshold to nodeDB, we can configure the size limit of each commit batch.
* This Pr changes `nodeDB` struct and `NewMutableTreeWithOpts` to replace uses of `dbm.Batch` to `BatchWithFlusher`
* We'll have to make changes to sdk accordingly to adapt this changes.