### PR TITLE
fix: memory leak in `Import`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - [#718](https://github.com/cosmos/iavl/pull/718) Fix `traverseNodes` unexpected behaviour
 - [#770](https://github.com/cosmos/iavl/pull/770) Add `WorkingVersion()int64` API.
 
+### Bug Fixes
+
+- [#]() Fix memory leak in `Import`.
+
 ### Breaking Changes
 
 - [#735](https://github.com/cosmos/iavl/pull/735) Pass logger to `NodeDB`, `MutableTree` and `ImmutableTree`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Bug Fixes
 
-- [#]() Fix memory leak in `Import`.
+- [#773](https://github.com/cosmos/iavl/pull/773) Fix memory leak in `Import`.
 
 ### Breaking Changes
 

--- a/import.go
+++ b/import.go
@@ -136,12 +136,6 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 		leftNode := i.stack[stackSize-2]
 		rightNode := i.stack[stackSize-1]
 
-		// remove the recursive references to avoid memory leak
-		leftNode.leftNode = nil
-		leftNode.rightNode = nil
-		rightNode.leftNode = nil
-		rightNode.rightNode = nil
-
 		node.leftNode = leftNode
 		node.rightNode = rightNode
 		node.leftNodeKey = leftNode.nodeKey
@@ -155,6 +149,12 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 			return err
 		}
 		i.stack = i.stack[:stackSize-2]
+
+		// remove the recursive references to avoid memory leak
+		leftNode.leftNode = nil
+		leftNode.rightNode = nil
+		rightNode.leftNode = nil
+		rightNode.rightNode = nil
 	}
 	i.nonces[exportNode.Version]++
 	node.nodeKey = &NodeKey{

--- a/import.go
+++ b/import.go
@@ -135,6 +135,15 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 	} else if stackSize >= 2 && i.stack[stackSize-1].subtreeHeight < node.subtreeHeight && i.stack[stackSize-2].subtreeHeight < node.subtreeHeight {
 		leftNode := i.stack[stackSize-2]
 		rightNode := i.stack[stackSize-1]
+
+		// remove the recursive references to avoid memory leak
+		leftNode.leftNode = nil
+		leftNode.rightNode = nil
+		rightNode.leftNode = nil
+		rightNode.rightNode = nil
+
+		node.leftNode = leftNode
+		node.rightNode = rightNode
 		node.leftNodeKey = leftNode.nodeKey
 		node.rightNodeKey = rightNode.nodeKey
 		node.size = leftNode.size + rightNode.size

--- a/import.go
+++ b/import.go
@@ -133,16 +133,16 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 	if node.subtreeHeight == 0 {
 		node.size = 1
 	} else if stackSize >= 2 && i.stack[stackSize-1].subtreeHeight < node.subtreeHeight && i.stack[stackSize-2].subtreeHeight < node.subtreeHeight {
-		node.leftNode = i.stack[stackSize-2]
-		node.rightNode = i.stack[stackSize-1]
-		node.leftNodeKey = node.leftNode.nodeKey
-		node.rightNodeKey = node.rightNode.nodeKey
-		node.size = node.leftNode.size + node.rightNode.size
+		leftNode := i.stack[stackSize-2]
+		rightNode := i.stack[stackSize-1]
+		node.leftNodeKey = leftNode.nodeKey
+		node.rightNodeKey = rightNode.nodeKey
+		node.size = leftNode.size + rightNode.size
 		// Update the stack now.
-		if err := i.writeNode(i.stack[stackSize-2]); err != nil {
+		if err := i.writeNode(leftNode); err != nil {
 			return err
 		}
-		if err := i.writeNode(i.stack[stackSize-1]); err != nil {
+		if err := i.writeNode(rightNode); err != nil {
 			return err
 		}
 		i.stack = i.stack[:stackSize-2]

--- a/nodedb.go
+++ b/nodedb.go
@@ -55,7 +55,7 @@ var (
 	metadataKeyFormat = keyformat.NewKeyFormat('m', 0) // m<keystring>
 )
 
-var errInvalidFastStorageVersion = fmt.Errorf("Fast storage version must be in the format <storage version>%s<latest fast cache version>", fastStorageVersionDelimiter)
+var errInvalidFastStorageVersion = fmt.Errorf("fast storage version must be in the format <storage version>%s<latest fast cache version>", fastStorageVersionDelimiter)
 
 type nodeDB struct {
 	logger log.Logger


### PR DESCRIPTION
Closes: #772 

don't need to reference the children, which recursively retain the whole subtree in memory.