### PR TITLE
feat: Add API `TraverseStateChanges` to extract state changes from iavl versions (backport: #654) 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - depguard
     - dogsled
     - errcheck
     - exportloopref

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Improvements
 
+- [#654](https://github.com/cosmos/iavl/pull/654) Add API `TraverseStateChanges` to extract state changes from iavl versions.
 - [#726](https://github.com/cosmos/iavl/pull/726) Make `KVPair` and `ChangeSet` serializable with protobuf.
 
 ## 0.20.0 (March 14, 2023)

--- a/basic_test.go
+++ b/basic_test.go
@@ -341,7 +341,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	for i, x := range records {
-		if val, removed, err := tree.Remove([]byte(x.key)); err != nil { //nolint:gocritic
+		if val, removed, err := tree.Remove([]byte(x.key)); err != nil {
 			require.NoError(t, err)
 		} else if !removed {
 			t.Error("Wasn't removed")

--- a/diff_test.go
+++ b/diff_test.go
@@ -21,35 +21,44 @@ func TestDiffRoundTrip(t *testing.T) {
 	db := db.NewMemDB()
 	tree, err := NewMutableTree(db, 0, true)
 	require.NoError(t, err)
-	for i := range changeSets {
-		v, err := tree.SaveChangeSet(changeSets[i])
+	for _, cs := range changeSets {
+		for _, pair := range cs.Pairs {
+			if pair.Delete {
+				_, removed, err := tree.Remove(pair.Key)
+				require.True(t, removed)
+				require.NoError(t, err)
+			} else {
+				_, err := tree.Set(pair.Key, pair.Value)
+				require.NoError(t, err)
+			}
+		}
+		_, _, err := tree.SaveVersion()
 		require.NoError(t, err)
-		require.Equal(t, int64(i+1), v)
 	}
 
 	// extract change sets from db
-	var extractChangeSets []*ChangeSet
+	var extractChangeSets []ChangeSet
 	tree2 := NewImmutableTree(db, 0, true)
-	err = tree2.ndb.traverseStateChanges(0, math.MaxInt64, func(version int64, changeSet *ChangeSet) error {
-		extractChangeSets = append(extractChangeSets, changeSet)
+	err = tree2.TraverseStateChanges(0, math.MaxInt64, func(version int64, changeSet *ChangeSet) error {
+		extractChangeSets = append(extractChangeSets, *changeSet)
 		return nil
 	})
 	require.NoError(t, err)
 	require.Equal(t, changeSets, extractChangeSets)
 }
 
-func genChangeSets(r *rand.Rand, n int) []*ChangeSet {
-	var changeSets []*ChangeSet
+func genChangeSets(r *rand.Rand, n int) []ChangeSet {
+	var changeSets []ChangeSet
 
 	for i := 0; i < n; i++ {
-		items := make(map[string]*KVPair)
+		items := make(map[string]KVPair)
 		start, count, step := r.Int63n(1000), r.Int63n(1000), r.Int63n(10)
 		for i := start; i < start+count*step; i += step {
 			value := make([]byte, 8)
 			binary.LittleEndian.PutUint64(value, uint64(i))
 
 			key := fmt.Sprintf("test-%d", i)
-			items[key] = &KVPair{
+			items[key] = KVPair{
 				Key:   []byte(key),
 				Value: value,
 			}
@@ -65,7 +74,7 @@ func genChangeSets(r *rand.Rand, n int) []*ChangeSet {
 				if pair.Delete {
 					continue
 				}
-				items[string(pair.Key)] = &KVPair{
+				items[string(pair.Key)] = KVPair{
 					Key:    pair.Key,
 					Delete: true,
 				}
@@ -77,7 +86,7 @@ func genChangeSets(r *rand.Rand, n int) []*ChangeSet {
 				i := r.Int63n(int64(len(lastChangeSet.Pairs)))
 				pair := lastChangeSet.Pairs[i]
 				if !pair.Delete {
-					items[string(pair.Key)] = &KVPair{
+					items[string(pair.Key)] = KVPair{
 						Key:   pair.Key,
 						Value: pair.Value,
 					}
@@ -93,10 +102,11 @@ func genChangeSets(r *rand.Rand, n int) []*ChangeSet {
 
 		var cs ChangeSet
 		for _, key := range keys {
-			cs.Pairs = append(cs.Pairs, items[key])
+			p := items[key]
+			cs.Pairs = append(cs.Pairs, &p)
 		}
 
-		changeSets = append(changeSets, &cs)
+		changeSets = append(changeSets, cs)
 	}
 	return changeSets
 }

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -331,3 +331,9 @@ func (t *ImmutableTree) nodeSize() int {
 	})
 	return size
 }
+
+// TraverseStateChanges iterate the range of versions, compare each version to it's predecessor to extract the state changes of it.
+// endVersion is exclusive.
+func (t *ImmutableTree) TraverseStateChanges(startVersion, endVersion int64, fn func(version int64, changeSet *ChangeSet) error) error {
+	return t.ndb.traverseStateChanges(startVersion, endVersion, fn)
+}

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -67,7 +67,7 @@ func (t *ImmutableTree) RenderShape(indent string, encoder NodeEncoder) ([]strin
 type NodeEncoder func(id []byte, depth int, isLeaf bool) string
 
 // defaultNodeEncoder can encode any node unless the client overrides it
-func defaultNodeEncoder(id []byte, depth int, isLeaf bool) string {
+func defaultNodeEncoder(id []byte, _ int, isLeaf bool) string {
 	prefix := "- "
 	if isLeaf {
 		prefix = "* "

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -377,7 +377,7 @@ func assertOrphans(t *testing.T, tree *MutableTree, expected int) {
 }
 
 // Checks that a version is the maximum mirrored version.
-func assertMaxVersion(t *testing.T, tree *MutableTree, version int64, mirrors map[int64]map[string]string) { //nolint:unparam
+func assertMaxVersion(t *testing.T, _ *MutableTree, version int64, mirrors map[int64]map[string]string) {
 	max := int64(0)
 	for v := range mirrors {
 		if v > max {


### PR DESCRIPTION
for more info, see https://github.com/cosmos/iavl/pull/654