### PR TITLE
docs: replace dead links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![API Reference](https://camo.githubusercontent.com/915b7be44ada53c290eb157634330494ebe3e30a/68747470733a2f2f676f646f632e6f72672f6769746875622e636f6d2f676f6c616e672f6764646f3f7374617475732e737667)](https://pkg.go.dev/github.com/cosmos/iavl)
 ![Lint](https://github.com/cosmos/iavl/workflows/Lint/badge.svg?branch=master)
 ![Test](https://github.com/cosmos/iavl/workflows/Test/badge.svg?branch=master)
-[![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/AzefAFd)
+[![Discord chat](https://img.shields.io/discord/669268347736686612.svg)](https://discord.gg/cosmosnetwork)
 
 Note: **Requires Go 1.18+**
 


### PR DESCRIPTION
Ensuring that old discord links are up to date for security purposes.