### PR TITLE
feat: Support concurrency for IAVL and fix Racing conditions

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1,6 +1,7 @@
 package iavl
 
 import (
+	"fmt"
 	"math/rand"
 	"sort"
 	"sync"
@@ -226,17 +227,17 @@ func iteratorSuccessTest(t *testing.T, config *iteratorTestConfig) {
 		assertIterator(t, itr, mirror, config.ascending)
 	}
 
-	t.Run("Iterator", func(t *testing.T) {
-		itr, mirror := setupIteratorAndMirror(t, config)
-		require.True(t, itr.Valid())
-		performTest(t, itr, mirror)
-	})
+	// t.Run("Iterator", func(t *testing.T) {
+	// 	itr, mirror := setupIteratorAndMirror(t, config)
+	// 	require.True(t, itr.Valid())
+	// 	performTest(t, itr, mirror)
+	// })
 
-	t.Run("Fast Iterator", func(t *testing.T) {
-		itr, mirror := setupFastIteratorAndMirror(t, config)
-		require.True(t, itr.Valid())
-		performTest(t, itr, mirror)
-	})
+	// t.Run("Fast Iterator", func(t *testing.T) {
+	// 	itr, mirror := setupFastIteratorAndMirror(t, config)
+	// 	require.True(t, itr.Valid())
+	// 	performTest(t, itr, mirror)
+	// })
 
 	t.Run("Unsaved Fast Iterator", func(t *testing.T) {
 		itr, mirror := setupUnsavedFastIterator(t, config)
@@ -323,6 +324,8 @@ func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Ite
 	}
 
 	itr := NewUnsavedFastIterator(config.startIterate, config.endIterate, config.ascending, tree.ndb, tree.unsavedFastNodeAdditions, tree.unsavedFastNodeRemovals)
+	fmt.Println("------")
+	fmt.Println(itr.Valid())
 	return itr, mirror
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -1,7 +1,6 @@
 package iavl
 
 import (
-	"fmt"
 	"math/rand"
 	"sort"
 	"sync"
@@ -227,17 +226,17 @@ func iteratorSuccessTest(t *testing.T, config *iteratorTestConfig) {
 		assertIterator(t, itr, mirror, config.ascending)
 	}
 
-	// t.Run("Iterator", func(t *testing.T) {
-	// 	itr, mirror := setupIteratorAndMirror(t, config)
-	// 	require.True(t, itr.Valid())
-	// 	performTest(t, itr, mirror)
-	// })
+	t.Run("Iterator", func(t *testing.T) {
+		itr, mirror := setupIteratorAndMirror(t, config)
+		require.True(t, itr.Valid())
+		performTest(t, itr, mirror)
+	})
 
-	// t.Run("Fast Iterator", func(t *testing.T) {
-	// 	itr, mirror := setupFastIteratorAndMirror(t, config)
-	// 	require.True(t, itr.Valid())
-	// 	performTest(t, itr, mirror)
-	// })
+	t.Run("Fast Iterator", func(t *testing.T) {
+		itr, mirror := setupFastIteratorAndMirror(t, config)
+		require.True(t, itr.Valid())
+		performTest(t, itr, mirror)
+	})
 
 	t.Run("Unsaved Fast Iterator", func(t *testing.T) {
 		itr, mirror := setupUnsavedFastIterator(t, config)
@@ -324,8 +323,6 @@ func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Ite
 	}
 
 	itr := NewUnsavedFastIterator(config.startIterate, config.endIterate, config.ascending, tree.ndb, tree.unsavedFastNodeAdditions, tree.unsavedFastNodeRemovals)
-	fmt.Println("------")
-	fmt.Println(itr.Valid())
 	return itr, mirror
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -3,11 +3,11 @@ package iavl
 import (
 	"math/rand"
 	"sort"
+	"sync"
 	"testing"
 
 	log "cosmossdk.io/log"
 	dbm "github.com/cosmos/cosmos-db"
-	"github.com/cosmos/iavl/fastnode"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,7 +37,7 @@ func TestIterator_NewIterator_NilTree_Failure(t *testing.T) {
 	})
 
 	t.Run("Unsaved Fast Iterator", func(t *testing.T) {
-		itr := NewUnsavedFastIterator(start, end, ascending, nil, map[string]*fastnode.Node{}, map[string]interface{}{})
+		itr := NewUnsavedFastIterator(start, end, ascending, nil, &sync.Map{}, &sync.Map{})
 		performTest(t, itr)
 		require.ErrorIs(t, errFastIteratorNilNdbGiven, itr.Error())
 	})
@@ -292,14 +292,14 @@ func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Ite
 	require.NoError(t, err)
 
 	// No unsaved additions or removals should be present after saving
-	require.Equal(t, 0, len(tree.unsavedFastNodeAdditions))
-	require.Equal(t, 0, len(tree.unsavedFastNodeRemovals))
+	require.Equal(t, 0, syncMapCount(tree.unsavedFastNodeAdditions))
+	require.Equal(t, 0, syncMapCount(tree.unsavedFastNodeRemovals))
 
 	// Ensure that there are unsaved additions and removals present
 	secondHalfMirror := setupMirrorForIterator(t, &secondHalfConfig, tree)
 
-	require.True(t, len(tree.unsavedFastNodeAdditions) >= len(secondHalfMirror))
-	require.Equal(t, 0, len(tree.unsavedFastNodeRemovals))
+	require.True(t, syncMapCount(tree.unsavedFastNodeAdditions) >= len(secondHalfMirror))
+	require.Equal(t, 0, syncMapCount(tree.unsavedFastNodeRemovals))
 
 	// Merge the two halves
 	if config.ascending {
@@ -366,4 +366,13 @@ func TestNodeIterator_WithEmptyRoot(t *testing.T) {
 	itr, err := NewNodeIterator(nil, newNodeDB(dbm.NewMemDB(), 0, nil, log.NewNopLogger()))
 	require.NoError(t, err)
 	require.False(t, itr.Valid())
+}
+
+func syncMapCount(m *sync.Map) int {
+	count := 0
+	m.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -34,10 +34,10 @@ var ErrKeyDoesNotExist = errors.New("key does not exist")
 type MutableTree struct {
 	logger log.Logger
 
-	*ImmutableTree                                     // The current, working tree.
-	lastSaved                *ImmutableTree            // The most recently saved tree.
-	unsavedFastNodeAdditions map[string]*fastnode.Node // FastNodes that have not yet been saved to disk
-	unsavedFastNodeRemovals  map[string]interface{}    // FastNodes that have not yet been removed from disk
+	*ImmutableTree                          // The current, working tree.
+	lastSaved                *ImmutableTree // The most recently saved tree.
+	unsavedFastNodeAdditions *sync.Map      // map[string]*FastNode FastNodes that have not yet been saved to disk
+	unsavedFastNodeRemovals  *sync.Map      // map[string]interface{} FastNodes that have not yet been removed from disk
 	ndb                      *nodeDB
 	skipFastStorageUpgrade   bool // If true, the tree will work like no fast storage and always not upgrade fast storage
 
@@ -58,8 +58,8 @@ func NewMutableTreeWithOpts(db dbm.DB, cacheSize int, opts *Options, skipFastSto
 		logger:                   lg,
 		ImmutableTree:            head,
 		lastSaved:                head.clone(),
-		unsavedFastNodeAdditions: make(map[string]*fastnode.Node),
-		unsavedFastNodeRemovals:  make(map[string]interface{}),
+		unsavedFastNodeAdditions: &sync.Map{},
+		unsavedFastNodeRemovals:  &sync.Map{},
 		ndb:                      ndb,
 		skipFastStorageUpgrade:   skipFastStorageUpgrade,
 	}
@@ -172,11 +172,11 @@ func (tree *MutableTree) Get(key []byte) ([]byte, error) {
 	}
 
 	if !tree.skipFastStorageUpgrade {
-		if fastNode, ok := tree.unsavedFastNodeAdditions[string(key)]; ok {
-			return fastNode.GetValue(), nil
+		if fastNode, ok := tree.unsavedFastNodeAdditions.Load(ibytes.UnsafeBytesToStr(key)); ok {
+			return fastNode.(*fastnode.Node).GetValue(), nil
 		}
 		// check if node was deleted
-		if _, ok := tree.unsavedFastNodeRemovals[string(key)]; ok {
+		if _, ok := tree.unsavedFastNodeRemovals.Load(string(key)); ok {
 			return nil, nil
 		}
 	}
@@ -655,8 +655,8 @@ func (tree *MutableTree) Rollback() {
 		}
 	}
 	if !tree.skipFastStorageUpgrade {
-		tree.unsavedFastNodeAdditions = map[string]*fastnode.Node{}
-		tree.unsavedFastNodeRemovals = map[string]interface{}{}
+		tree.unsavedFastNodeAdditions = &sync.Map{}
+		tree.unsavedFastNodeRemovals = &sync.Map{}
 	}
 }
 
@@ -774,8 +774,8 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 	tree.ImmutableTree = tree.ImmutableTree.clone()
 	tree.lastSaved = tree.ImmutableTree.clone()
 	if !tree.skipFastStorageUpgrade {
-		tree.unsavedFastNodeAdditions = make(map[string]*fastnode.Node)
-		tree.unsavedFastNodeRemovals = make(map[string]interface{})
+		tree.unsavedFastNodeAdditions = &sync.Map{}
+		tree.unsavedFastNodeRemovals = &sync.Map{}
 	}
 
 	hash := tree.Hash()
@@ -793,30 +793,45 @@ func (tree *MutableTree) saveFastNodeVersion(isGenesis bool) error {
 	return tree.ndb.setFastStorageVersionToBatch()
 }
 
+// nolint: unused
 func (tree *MutableTree) getUnsavedFastNodeAdditions() map[string]*fastnode.Node {
-	return tree.unsavedFastNodeAdditions
+	additions := make(map[string]*fastnode.Node)
+	tree.unsavedFastNodeAdditions.Range(func(key, value interface{}) bool {
+		additions[key.(string)] = value.(*fastnode.Node)
+		return true
+	})
+	return additions
 }
 
 // getUnsavedFastNodeRemovals returns unsaved FastNodes to remove
 
 func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
-	return tree.unsavedFastNodeRemovals
+	removals := make(map[string]interface{})
+	tree.unsavedFastNodeRemovals.Range(func(key, value interface{}) bool {
+		removals[key.(string)] = value
+		return true
+	})
+	return removals
 }
 
+// addUnsavedAddition stores an addition into the unsaved additions map
 func (tree *MutableTree) addUnsavedAddition(key []byte, node *fastnode.Node) {
-	delete(tree.unsavedFastNodeRemovals, ibytes.UnsafeBytesToStr(key))
-	tree.unsavedFastNodeAdditions[string(key)] = node
+	skey := ibytes.UnsafeBytesToStr(key)
+	tree.unsavedFastNodeRemovals.Delete(skey)
+	tree.unsavedFastNodeAdditions.Store(skey, node)
 }
 
 func (tree *MutableTree) saveFastNodeAdditions(batchCommmit bool) error {
-	keysToSort := make([]string, 0, len(tree.unsavedFastNodeAdditions))
-	for key := range tree.unsavedFastNodeAdditions {
-		keysToSort = append(keysToSort, key)
-	}
+	keysToSort := make([]string, 0)
+	tree.unsavedFastNodeAdditions.Range(func(k, v interface{}) bool {
+		keysToSort = append(keysToSort, k.(string))
+		return true
+	})
 	sort.Strings(keysToSort)
 
 	for _, key := range keysToSort {
-		if err := tree.ndb.SaveFastNode(tree.unsavedFastNodeAdditions[key]); err != nil {
+		val, _ := tree.unsavedFastNodeAdditions.Load(key)
+		if err := tree.ndb.SaveFastNode(val.(*fastnode.Node)); err != nil {
 			return err
 		}
 		if batchCommmit {
@@ -828,17 +843,19 @@ func (tree *MutableTree) saveFastNodeAdditions(batchCommmit bool) error {
 	return nil
 }
 
+// addUnsavedRemoval adds a removal to the unsaved removals map
 func (tree *MutableTree) addUnsavedRemoval(key []byte) {
 	skey := ibytes.UnsafeBytesToStr(key)
-	delete(tree.unsavedFastNodeAdditions, skey)
-	tree.unsavedFastNodeRemovals[skey] = true
+	tree.unsavedFastNodeAdditions.Delete(skey)
+	tree.unsavedFastNodeRemovals.Store(skey, true)
 }
 
 func (tree *MutableTree) saveFastNodeRemovals() error {
-	keysToSort := make([]string, 0, len(tree.unsavedFastNodeRemovals))
-	for key := range tree.unsavedFastNodeRemovals {
-		keysToSort = append(keysToSort, key)
-	}
+	keysToSort := make([]string, 0)
+	tree.unsavedFastNodeRemovals.Range(func(k, v interface{}) bool {
+		keysToSort = append(keysToSort, k.(string))
+		return true
+	})
 	sort.Strings(keysToSort)
 
 	for _, key := range keysToSort {

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -85,7 +84,6 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 			return true
 		}
 
-		fmt.Println(fastNode.GetKey())
 		// convert key to bytes. Type conversion failure should not happen in practice
 		iter.unsavedFastNodesToSort = append(iter.unsavedFastNodesToSort, k.(string))
 

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -3,7 +3,6 @@ package iavl
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 
@@ -61,10 +60,8 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 	}
 
 	if iter.unsavedFastNodeAdditions == nil {
-		fmt.Println(iter.unsavedFastNodeAdditions)
 		iter.err = errUnsavedFastIteratorNilAdditionsGiven
 		iter.valid = false
-		fmt.Println(iter.err)
 		return iter
 	}
 


### PR DESCRIPTION
cref: https://github.com/cosmos/iavl/issues/696

This PR fixes the problem stated above by replacing maps that causes racing conditions to sync map to be thread safe. 

Tested this on various chains' nodes that's having concurrency issue by applying patch manually, confirmed that after applying this patch concurrency issue is not happening any more. (special shout out to @keplr-wallet for helping out testing!)

Also confirmed and tested on a testnet node with the following procedure:
- Have node running 
- Spam it with tx bots and query bots
- Previously node would crash within 1, maximum 2 minutes with the racing condition logs mentioned above
