### PR TITLE
feat: Uses BatchWithFlusher in iavl tree

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -8,22 +8,20 @@ import (
 // around batch that flushes batch's data to disk
 // as soon as the configurable limit is reached.
 type BatchWithFlusher struct {
-	db             dbm.DB    // This is only used to create new batch
-	batch          dbm.Batch // Batched writing buffer.
-	flushThreshold int       // The maximum size of the batch in bytes before it gets flushed to disk
+	db    dbm.DB    // This is only used to create new batch
+	batch dbm.Batch // Batched writing buffer.
 }
 
 var _ dbm.Batch = &BatchWithFlusher{}
 
 // Ethereum has found that commit of 100KB is optimal, ref ethereum/go-ethereum#15115
-// var defaultFlushThreshold = 100000
+var flushThreshold = 100000
 
 // NewBatchWithFlusher returns new BatchWithFlusher wrapping the passed in batch
-func NewBatchWithFlusher(db dbm.DB, flushThreshold int) *BatchWithFlusher {
+func NewBatchWithFlusher(db dbm.DB) *BatchWithFlusher {
 	return &BatchWithFlusher{
-		db:             db,
-		batch:          db.NewBatchWithSize(flushThreshold),
-		flushThreshold: flushThreshold,
+		db:    db,
+		batch: db.NewBatchWithSize(flushThreshold),
 	}
 }
 
@@ -44,7 +42,7 @@ func (b *BatchWithFlusher) estimateSizeAfterSetting(key []byte, value []byte) (i
 }
 
 // Set sets value at the given key to the db.
-// If the set causes the underlying batch size to exceed batchSizeFlushThreshold,
+// If the set causes the underlying batch size to exceed flushThreshold,
 // the batch is flushed to disk, cleared, and a new one is created with buffer pre-allocated to threshold.
 // The addition entry is then added to the batch.
 func (b *BatchWithFlusher) Set(key []byte, value []byte) error {
@@ -52,7 +50,7 @@ func (b *BatchWithFlusher) Set(key []byte, value []byte) error {
 	if err != nil {
 		return err
 	}
-	if batchSizeAfter > b.flushThreshold {
+	if batchSizeAfter > flushThreshold {
 		err = b.batch.Write()
 		if err != nil {
 			return err
@@ -61,7 +59,7 @@ func (b *BatchWithFlusher) Set(key []byte, value []byte) error {
 		if err != nil {
 			return err
 		}
-		b.batch = b.db.NewBatchWithSize(b.flushThreshold)
+		b.batch = b.db.NewBatchWithSize(flushThreshold)
 	}
 	err = b.batch.Set(key, value)
 	if err != nil {
@@ -79,7 +77,7 @@ func (b *BatchWithFlusher) Delete(key []byte) error {
 	if err != nil {
 		return err
 	}
-	if batchSizeAfter > b.flushThreshold {
+	if batchSizeAfter > flushThreshold {
 		err = b.batch.Write()
 		if err != nil {
 			return err
@@ -88,7 +86,7 @@ func (b *BatchWithFlusher) Delete(key []byte) error {
 		if err != nil {
 			return err
 		}
-		b.batch = b.db.NewBatchWithSize(b.flushThreshold)
+		b.batch = b.db.NewBatchWithSize(flushThreshold)
 	}
 	err = b.batch.Delete(key)
 	if err != nil {

--- a/batch_test.go
+++ b/batch_test.go
@@ -31,15 +31,12 @@ func TestBatchWithFlusher(t *testing.T) {
 		dbm.GoLevelDBBackend,
 	}
 
-	// we test batch writing data of size 10MBs with different flush threshold
-	for _, flushThreshold := range []int{100000, 1000000, 10000000} {
-		for _, backend := range testedBackends {
-			testBatchWithFlusher(t, backend, flushThreshold)
-		}
+	for _, backend := range testedBackends {
+		testBatchWithFlusher(t, backend)
 	}
 }
 
-func testBatchWithFlusher(t *testing.T, backend dbm.BackendType, flushThreshold int) {
+func testBatchWithFlusher(t *testing.T, backend dbm.BackendType) {
 	name := fmt.Sprintf("test_%x", randstr(12))
 	dir := t.TempDir()
 	db, err := dbm.NewDB(name, backend, dir)

--- a/batch_test.go
+++ b/batch_test.go
@@ -26,42 +26,6 @@ func makeKey(n uint16) []byte {
 	return key
 }
 
-func BenchmarkBatchWithFlusher(b *testing.B) {
-	testedBackends := []dbm.BackendType{
-		dbm.GoLevelDBBackend,
-	}
-
-	// we benchmark batch writing data of size 10MBs with different flush threshold
-	for _, flushThreshold := range []int{100000, 1000000, 10000000} {
-		for _, backend := range testedBackends {
-			b.Run(fmt.Sprintf("threshold=%d/backend=%s", flushThreshold, backend), func(b *testing.B) {
-				benchmarkBatchWithFlusher(b, backend, flushThreshold)
-			})
-		}
-	}
-}
-
-func benchmarkBatchWithFlusher(b *testing.B, backend dbm.BackendType, flushThreshold int) {
-	name := fmt.Sprintf("test_%x", randstr(12))
-	dir := b.TempDir()
-	db, err := dbm.NewDB(name, backend, dir)
-	require.NoError(b, err)
-	defer cleanupDBDir(dir, name)
-
-	batchWithFlusher := NewBatchWithFlusher(db, flushThreshold)
-
-	// we'll try to to commit 10MBs (1000 * 10KBs each entries) of data into the db
-	for keyNonce := uint16(0); keyNonce < 1000; keyNonce++ {
-		// each key / value is 10 KBs of zero bytes
-		key := makeKey(keyNonce)
-		err := batchWithFlusher.Set(key, bytesArrayOfSize10KB[:])
-		if err != nil {
-			panic(err)
-		}
-	}
-	require.NoError(b, batchWithFlusher.Write())
-}
-
 func TestBatchWithFlusher(t *testing.T) {
 	testedBackends := []dbm.BackendType{
 		dbm.GoLevelDBBackend,
@@ -82,7 +46,7 @@ func testBatchWithFlusher(t *testing.T, backend dbm.BackendType, flushThreshold 
 	require.NoError(t, err)
 	defer cleanupDBDir(dir, name)
 
-	batchWithFlusher := NewBatchWithFlusher(db, flushThreshold)
+	batchWithFlusher := NewBatchWithFlusher(db)
 
 	// we'll try to to commit 10MBs (1000 * 10KBs each entries) of data into the db
 	for keyNonce := uint16(0); keyNonce < 1000; keyNonce++ {

--- a/nodedb.go
+++ b/nodedb.go
@@ -100,7 +100,7 @@ func newNodeDB(db dbm.DB, cacheSize int, opts *Options, lg log.Logger) *nodeDB {
 	return &nodeDB{
 		logger:              lg,
 		db:                  db,
-		batch:               db.NewBatch(),
+		batch:               NewBatchWithFlusher(db),
 		opts:                *opts,
 		firstVersion:        0,
 		latestVersion:       0, // initially invalid
@@ -382,7 +382,7 @@ func (ndb *nodeDB) writeBatch() error {
 		return err
 	}
 
-	ndb.batch = ndb.db.NewBatch()
+	ndb.batch = NewBatchWithFlusher(ndb.db)
 
 	return nil
 }
@@ -877,7 +877,7 @@ func (ndb *nodeDB) Commit() error {
 	}
 
 	ndb.batch.Close()
-	ndb.batch = ndb.db.NewBatch()
+	ndb.batch = NewBatchWithFlusher(ndb.db)
 
 	return nil
 }


### PR DESCRIPTION
This PR replace the use of normal dbm.Batch with BatchWithFlusher in iavl tree
It also hard code the value of flushthreshold to 100KB