### PR TITLE
chore: retract v0.21.x line

### DIFF
--- a/.mergify.yaml
+++ b/.mergify.yaml
@@ -32,14 +32,6 @@ pull_request_rules:
       backport:
         branches:
           - release/v0.20.x
-  - name: backport patches to v0.21.x branch
-    conditions:
-      - base=master
-      - label=backport/v0.21.x
-    actions:
-      backport:
-        branches:
-          - release/v0.21.x
   - name: backport patches to v1.x branch
     conditions:
       - base=master

--- a/README.md
+++ b/README.md
@@ -27,5 +27,6 @@ In Ethereum, the analog is [Patricia tries](http://en.wikipedia.org/wiki/Radix_t
 | -------------------------------------------------------------- | -------------------------------------------------------- | ---------------- |
 | [v0.19.x](https://github.com/cosmos/iavl/tree/release/v0.19.x) | [`tm-db`](https://github.com/tendermint/tm-db)           | v0.45.x, v0.46.x |
 | [v0.20.x](https://github.com/cosmos/iavl/tree/release/v0.20.x) | [`cometbft-db`](https://github.com/cometbft/cometbft-db) | v0.47.x          |
-| [v0.21.x](https://github.com/cosmos/iavl/tree/release/v0.21.x) | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |
 | [v1.x.x](https://github.com/cosmos/iavl/tree/release/v1.x.x)   | [`cosmos-db`](https://github.com/cosmos/cosmos-db)       | -                |
+
+NOTE: In the past, a v0.21.x release was published, but never used in production. It was retracted to avoid confusion.

--- a/export_test.go
+++ b/export_test.go
@@ -126,7 +126,7 @@ func setupExportTreeRandom(t *testing.T) *ImmutableTree {
 
 // setupExportTreeSized sets up a single-version tree with a given number
 // of randomly generated key/value pairs, useful for benchmarking.
-func setupExportTreeSized(t require.TestingT, treeSize int) *ImmutableTree { //nolint:unparam
+func setupExportTreeSized(t require.TestingT, treeSize int) *ImmutableTree {
 	const (
 		randSeed  = 49872768940 // For deterministic tests
 		keySize   = 16

--- a/go.mod
+++ b/go.mod
@@ -47,4 +47,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-retract v0.18.0
+retract (
+	v0.18.0
+	// This version is not used by the Cosmos SDK and adds a maintenance burden.
+	// Use v1.x.x instead.
+	[v0.21.0, v0.21.1, v0.21.2]
+)

--- a/go.mod
+++ b/go.mod
@@ -51,5 +51,5 @@ retract (
 	v0.18.0
 	// This version is not used by the Cosmos SDK and adds a maintenance burden.
 	// Use v1.x.x instead.
-	[v0.21.0, v0.21.1, v0.21.2]
+	[v0.21.0, v0.21.2]
 )


### PR DESCRIPTION
The v0.21 line is unused and should be retracted to avoid maintenance burden and confusion about releases.
- https://sourcegraph.com/search?q=context%3Aglobal+iavl+v0.21&patternType=standard&sm=1&groupBy=repo
Both results indicate that the indirect dependency on v0.21 is replaced by respectively v0.20.0 and v0.19.4 in the go.mod.