### PR TITLE
feat: async commit

### DIFF
--- a/basic_test.go
+++ b/basic_test.go
@@ -448,6 +448,7 @@ func TestPersistence(t *testing.T) {
 	t1.SaveVersion()
 
 	// Load a tree
+	t1.ndb.waitAsyncWrite()
 	t2 := NewMutableTree(db, 0, false, log.NewNopLogger())
 	t2.Load()
 	for key, value := range records {

--- a/cache/node_cache.go
+++ b/cache/node_cache.go
@@ -1,0 +1,101 @@
+package cache
+
+import "sync"
+
+// WriteNode is a node that can be written to the cache.
+type WriteNode interface {
+	Node
+
+	// GetVersion returns the version of the node.
+	GetVersion() int64
+}
+
+// NodeCache is a cache for writing nodes asynchronously.
+type NodeCache interface {
+	Cache
+
+	// SetVersion sets the version of the cache that allows it to delete nodes.
+	SetVersion(version int64)
+}
+
+// nodeCache is a wrapper around a Cache.
+// It is used to maintain nodes up to a certain version for asynchonous writes.
+type nodeCache struct {
+	c *lruCache
+
+	version int64 // can delete nodes from cache up to this version
+	mtx     sync.RWMutex
+}
+
+// NewNodeCache returns a new nodeCache.
+func NewNodeCache(maxElementCount int) NodeCache {
+	return &nodeCache{
+		c: New(maxElementCount).(*lruCache),
+	}
+}
+
+// Add adds a node to the cache.
+func (nc *nodeCache) Add(node Node) Node {
+	nc.mtx.Lock()
+	defer nc.mtx.Unlock()
+
+	if e, exists := nc.c.dict[string(node.GetKey())]; exists {
+		nc.c.ll.MoveToFront(e)
+		old := e.Value
+		e.Value = node
+		return old.(Node)
+	}
+
+	elem := nc.c.ll.PushFront(node)
+	nc.c.dict[string(node.GetKey())] = elem
+
+	for nc.c.Len() > nc.c.maxElementCount {
+		oldest := nc.c.ll.Back()
+		if oldest.Value.(WriteNode).GetVersion() > nc.version {
+			break
+		}
+		nc.c.remove(oldest)
+	}
+
+	return nil
+}
+
+// Get gets a node from the cache.
+func (nc *nodeCache) Get(key []byte) Node {
+	nc.mtx.RLock()
+	defer nc.mtx.RUnlock()
+
+	return nc.c.Get(key)
+}
+
+// Has returns true if the cache has the key.
+func (nc *nodeCache) Has(key []byte) bool {
+	nc.mtx.RLock()
+	defer nc.mtx.RUnlock()
+
+	return nc.c.Has(key)
+}
+
+// Len returns the number of nodes in the cache.
+func (nc *nodeCache) Len() int {
+	nc.mtx.RLock()
+	defer nc.mtx.RUnlock()
+
+	return nc.c.Len()
+}
+
+// Remove removes a node from the cache.
+func (nc *nodeCache) Remove(key []byte) Node {
+	nc.mtx.Lock()
+	defer nc.mtx.Unlock()
+
+	return nc.c.Remove(key)
+}
+
+// SetVersion sets the version of the cache.
+func (nc *nodeCache) SetVersion(version int64) {
+	nc.mtx.Lock()
+	defer nc.mtx.Unlock()
+
+	nc.version = version
+}

--- a/diff_test.go
+++ b/diff_test.go
@@ -26,6 +26,7 @@ func TestDiffRoundTrip(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, int64(i+1), v)
 	}
+	tree.ndb.waitAsyncWrite()
 
 	// extract change sets from db
 	var extractChangeSets []*ChangeSet

--- a/docs/architecture/adr-002-api-cleanup.md
+++ b/docs/architecture/adr-002-api-cleanup.md
@@ -1,0 +1,93 @@
+# ADR ADR-002: API Cleanup to Improve Commit Performance
+
+## Changelog
+
+* 2023-06-06: First draft
+
+## Status
+
+DRAFT
+
+## Abstract
+
+This ADR proposes a cleanup of the API to make more understandable and maintainable the codebase of `iavl`.
+
+There is a lot of legacy code in the SDK that is not used anymore and can be removed. See the [Discussion](https://github.com/cosmos/iavl/issues/737) for more details.
+
+There are some proposals for the speedup of the `Commit` by the async writes. See the [Discussion](https://github.com/cosmos/cosmos-sdk/issues/16173) for more details.
+
+## Context
+
+The current implementation of `iavl` suffers from performance issues due to synchronous writes during the `Commit` process. To address this, the proposed changes aim to finalize the current version in memory and introduce asynchronous writes in the background.
+
+It is also necessary to refactor the `Set` function to accept a batch object for the atomic commitments.
+
+Moreover, the existing architecture of `iavl` lacks modularity and code organization:
+
+* The boundary between `ImmutableTree` and `MutableTree` is not clear.
+* There are many public methods in `nodeDB`, making it less structured.
+
+## Decision
+
+To make the codebase more clear and improve `Commit` performance, we propose the following changes:
+
+### Batch Set
+
+* Refactor the `Set` function to accept a batch object.
+* Eliminate the usage of `dbm.Batch` in `nodeDB`.
+
+### Async Commit
+
+* Finalize the current version in memory during `Commit`.
+* Perform async writes in the background.
+
+### API Cleanup
+
+* Make `nodeDB` methods private and remove all unused methods.
+* Follow the naming convention of the `store` module.
+
+The exposed API of `iavl` will be as follows:
+
+```go
+    MutableTree interface {
+        SaveChangeSet(cs *ChangeSet) ([]byte, error) // this is for batch set
+        WorkingHash() []byte
+        Commit() ([]byte, int64, error) // SaveVersion -> Commit
+        Close() error // this is to make sure the async write is finished when shutdown
+        DeleteVersionsTo(version int64) error
+        LoadVersionForOverwriting(targetVersion int64) error
+        GetImmutableTree(version int64) (*ImmutableTree, error)
+    }
+
+    ImmutableTree interface {
+        Has(key []byte) (bool, error)
+        Get(key []byte) ([]byte, error)
+        Hash() []byte
+        Iterator(start, end []byte, ascending bool) (types.Iterator, error)
+        VersionExists(version int64) bool
+        GetVersionedProof(key []byte, version int64) ([]byte, *cmtprotocrypto.ProofOps, error)
+    }
+```
+
+## Consequences
+
+We expect the proposed changes to improve the performance of Commit through async writes. Additionally, the codebase will become more organized and maintainable.
+
+### Backwards Compatibility
+
+While this ADR will break the external API of `iavl`, it will not affect the internal state of nodeDB. Compatibility measures and migration steps will be necessary during the API cleanup to handle the breaking changes.
+
+### Positive
+
+* Atomicity of the `Commitments`.
+* Improved Commit performance through async writes.
+* Increased flexibility and ease of modification and refactoring for iavl.
+
+### Negative
+
+* Async Commit may result in increased memory usage and increased code complexity.
+
+## References
+
+* <https://github.com/cosmos/cosmos-sdk/issues/16173>
+* <https://github.com/cosmos/iavl/issues/737>

--- a/export.go
+++ b/export.go
@@ -53,7 +53,7 @@ func newExporter(tree *ImmutableTree) (*Exporter, error) {
 		cancel: cancel,
 	}
 
-	tree.ndb.incrVersionReaders(tree.version)
+	tree.ndb.incrVersionReaderWriters(tree.version)
 	go exporter.export(ctx)
 
 	return exporter, nil
@@ -93,7 +93,7 @@ func (e *Exporter) Close() {
 	for range e.ch { // drain channel
 	}
 	if e.tree != nil {
-		e.tree.ndb.decrVersionReaders(e.tree.version)
+		e.tree.ndb.decrVersionReaderWriters(e.tree.version)
 	}
 	e.tree = nil
 }

--- a/export_test.go
+++ b/export_test.go
@@ -346,6 +346,7 @@ func TestExporter_DeleteVersionErrors(t *testing.T) {
 	require.NoError(t, err)
 	defer exporter.Close()
 
+	tree.ndb.waitAsyncWrite()
 	err = tree.DeleteVersionsTo(1)
 	require.NoError(t, err)
 

--- a/import_test.go
+++ b/import_test.go
@@ -96,6 +96,7 @@ func TestImporter_NotEmptyDatabase(t *testing.T) {
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	tree = NewMutableTree(db, 0, false, log.NewNopLogger())
 	_, err = tree.Load()
 	require.NoError(t, err)

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -178,6 +178,7 @@ func TestIterator_WithDelete_Full_Ascending_Success(t *testing.T) {
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	err = tree.DeleteVersionsTo(1)
 	require.NoError(t, err)
 
@@ -252,6 +253,7 @@ func setupIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.Itera
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	latestVersion, err := tree.ndb.getLatestVersion()
 	require.NoError(t, err)
 	immutableTree, err := tree.GetImmutable(latestVersion)
@@ -268,6 +270,7 @@ func setupFastIteratorAndMirror(t *testing.T, config *iteratorTestConfig) (dbm.I
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	itr := NewFastIterator(config.startIterate, config.endIterate, config.ascending, tree.ndb)
 	return itr, mirror
 }
@@ -290,6 +293,8 @@ func setupUnsavedFastIterator(t *testing.T, config *iteratorTestConfig) (dbm.Ite
 	mirror := setupMirrorForIterator(t, &firstHalfConfig, tree)
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
+
+	tree.ndb.waitAsyncWrite()
 
 	// No unsaved additions or removals should be present after saving
 	require.Equal(t, 0, len(tree.unsavedFastNodeAdditions))

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -118,6 +118,7 @@ func TestLegacyReferenceNode(t *testing.T) {
 	require.NoError(t, err)
 
 	// Load the previous version
+	tree.ndb.waitAsyncWrite()
 	newTree := NewMutableTree(db, 1000, false, log.NewNopLogger())
 	_, err = newTree.LoadVersion(version - 1)
 	require.NoError(t, err)

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -80,6 +80,7 @@ func TestLazySet(t *testing.T) {
 		require.NoError(t, err)
 	}
 
+	tree.ndb.waitAsyncWrite()
 	tree = NewMutableTree(db, 1000, false, log.NewNopLogger())
 
 	// Verify that the latest legacy version can still be loaded

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -768,9 +768,7 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		}
 	}
 
-	if err := tree.ndb.Commit(); err != nil {
-		return nil, version, err
-	}
+	tree.ndb.saveVersion(version)
 
 	tree.version = version
 
@@ -1080,4 +1078,9 @@ func (tree *MutableTree) SaveChangeSet(cs *ChangeSet) (int64, error) {
 	}
 	_, version, err := tree.SaveVersion()
 	return version, err
+}
+
+// Close closes the underlying NodeDB.
+func (tree *MutableTree) Close() error {
+	return tree.ndb.close()
 }

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -777,7 +777,6 @@ func (tree *MutableTree) saveFastNodeVersion() error {
 	return tree.ndb.setFastStorageVersionToBatch()
 }
 
-// nolint: unused
 func (tree *MutableTree) getUnsavedFastNodeAdditions() map[string]*fastnode.Node {
 	additions := make(map[string]*fastnode.Node)
 	tree.unsavedFastNodeAdditions.Range(func(key, value interface{}) bool {
@@ -788,7 +787,6 @@ func (tree *MutableTree) getUnsavedFastNodeAdditions() map[string]*fastnode.Node
 }
 
 // getUnsavedFastNodeRemovals returns unsaved FastNodes to remove
-
 func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
 	removals := make(map[string]interface{})
 	tree.unsavedFastNodeRemovals.Range(func(key, value interface{}) bool {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -536,6 +536,9 @@ func (tree *MutableTree) LoadVersionForOverwriting(targetVersion int64) error {
 		}
 	}
 
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
+
 	return nil
 }
 
@@ -717,15 +720,12 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 	tree.logger.Debug("SAVE TREE", "version", version)
 	// save new nodes
 	if tree.root == nil {
-		if err := tree.ndb.SaveEmptyRoot(version); err != nil {
-			return nil, 0, err
-		}
+		tree.ndb.SaveEmptyRoot(version)
 	} else {
 		if tree.root.nodeKey != nil {
 			// it means there is no updated
-			if err := tree.ndb.SaveRoot(version, tree.root.nodeKey.version); err != nil {
-				return nil, 0, err
-			}
+			tree.ndb.SaveRoot(version, tree.root.nodeKey.version)
+
 			// it means the reference node is a legacy node
 			if tree.root.nodeKey.nonce == 0 {
 				// it will update the legacy node to the new format

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -742,6 +742,8 @@ func (tree *MutableTree) SaveVersion() ([]byte, int64, error) {
 		}
 	}
 
+	tree.ndb.resetLatestVersion(version)
+
 	if !tree.skipFastStorageUpgrade {
 		if err := tree.saveFastNodeVersion(); err != nil {
 			return nil, version, err

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -219,6 +219,8 @@ func TestMutableTree_DeleteVersionsTo(t *testing.T) {
 	}
 
 	// delete even versions
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
 	versionToDelete := int64(8)
 	require.NoError(t, tree.DeleteVersionsTo(versionToDelete))
 

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1018,7 +1018,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 
 func TestUpgradeStorageToFast_Integration_Upgraded_FastIterator_Success(t *testing.T) {
 	// Setup
-	tree, mirror := setupTreeAndMirror(t, 100, false)
+	tree, mirror := setupTreeAndMirror(t, 200, false)
 
 	isFastCacheEnabled, err := tree.IsFastCacheEnabled()
 	require.NoError(t, err)

--- a/node.go
+++ b/node.go
@@ -69,7 +69,7 @@ type Node struct {
 	subtreeHeight int8
 }
 
-var _ cache.Node = (*Node)(nil)
+var _ cache.WriteNode = (*Node)(nil)
 
 // NewNode returns a new node from a key, value and version.
 func NewNode(key []byte, value []byte) *Node {
@@ -84,6 +84,11 @@ func NewNode(key []byte, value []byte) *Node {
 // GetKey returns the key of the node.
 func (node *Node) GetKey() []byte {
 	return node.nodeKey.GetKey()
+}
+
+// GetVersion returns the version of the node.
+func (node *Node) GetVersion() int64 {
+	return node.nodeKey.version
 }
 
 // MakeNode constructs an *Node from an encoded byte slice.

--- a/nodedb.go
+++ b/nodedb.go
@@ -269,7 +269,6 @@ func (ndb *nodeDB) writeFastNode(node *fastnode.Node) error {
 
 // saveVersion lets the async write goroutine know to commit the batch.
 func (ndb *nodeDB) saveVersion(version int64) {
-	ndb.resetLatestVersion(version)
 	ndb.incrVersionReaderWriters(version)
 	// push the version to the async write channel
 	ndb.chWrite <- version

--- a/nodedb.go
+++ b/nodedb.go
@@ -909,9 +909,6 @@ func (ndb *nodeDB) getFastIterator(start, end []byte, ascending bool) (dbm.Itera
 
 // Write to disk.
 func (ndb *nodeDB) Commit() error {
-	ndb.mtx.Lock()
-	defer ndb.mtx.Unlock()
-
 	var err error
 	if ndb.opts.Sync {
 		err = ndb.batch.WriteSync()

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -93,7 +93,6 @@ func TestSetStorageVersion_Success(t *testing.T) {
 	latestVersion, err := ndb.getLatestVersion()
 	require.NoError(t, err)
 	require.Equal(t, expectedVersion+fastStorageVersionDelimiter+strconv.Itoa(int(latestVersion)), ndb.getStorageVersion())
-	require.NoError(t, ndb.batch.Write())
 }
 
 func TestSetStorageVersion_InvalidVersionFailure_OldKept(t *testing.T) {

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -277,6 +277,7 @@ func TestTraverseNodes(t *testing.T) {
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	count := 0
 	err = tree.ndb.traverseNodes(func(node *Node) error {
 		actualNode, err := tree.ndb.GetNode(node.GetKey())

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -117,6 +117,7 @@ func expectTraverse(t *testing.T, trav traverser, start, end string, count int) 
 }
 
 func assertMutableMirrorIterate(t *testing.T, tree *MutableTree, mirror map[string]string) {
+	tree.ndb.waitAsyncWrite()
 	sortedMirrorKeys := make([]string, 0, len(mirror))
 	for k := range mirror {
 		sortedMirrorKeys = append(sortedMirrorKeys, k)

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -257,6 +257,7 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 	}
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
+	tree.ndb.waitAsyncWrite()
 	err = tree.DeleteVersionsTo(prevVersion)
 	require.NoError(t, err)
 	assertEmptyDatabase(t, tree)

--- a/tree_random_test.go
+++ b/tree_random_test.go
@@ -152,6 +152,8 @@ func testRandomOperations(t *testing.T, randSeed int64) {
 			version, tree.Size(), len(tree.AvailableVersions()))
 
 		// Verify that the version matches the mirror.
+		tree.ndb.waitAsyncWrite()
+		tree.ndb.startAsyncWrite()
 		assertMirror(t, tree, mirror, 0)
 
 		// Save the mirror as a disk mirror, since we currently persist all versions.

--- a/tree_test.go
+++ b/tree_test.go
@@ -911,6 +911,8 @@ func TestVersionedCheckpointsSpecialCase2(_ *testing.T) {
 	tree.Set([]byte("X"), []byte("New"))
 	tree.SaveVersion()
 
+	tree.ndb.waitAsyncWrite()
+
 	tree.DeleteVersionsTo(1)
 	tree.DeleteVersionsTo(2)
 }
@@ -929,6 +931,8 @@ func TestVersionedCheckpointsSpecialCase3(_ *testing.T) {
 	tree.Set([]byte("l"), []byte("bhIpltPM"))
 	tree.Set([]byte("B"), []byte("rj97IKZh"))
 	tree.SaveVersion()
+
+	tree.ndb.waitAsyncWrite()
 
 	tree.DeleteVersionsTo(2)
 
@@ -985,6 +989,8 @@ func TestVersionedCheckpointsSpecialCase5(_ *testing.T) {
 	tree.Set([]byte("R"), []byte("vQDaoz6Z"))
 	tree.SaveVersion()
 
+	tree.ndb.waitAsyncWrite()
+
 	tree.DeleteVersionsTo(1)
 
 	tree.GetVersioned([]byte("R"), 2)
@@ -1009,6 +1015,8 @@ func TestVersionedCheckpointsSpecialCase6(_ *testing.T) {
 	tree.Set([]byte("7"), []byte("bn62vWbq"))
 	tree.Set([]byte("5"), []byte("wZuLGDkZ"))
 	tree.SaveVersion()
+
+	tree.ndb.waitAsyncWrite()
 
 	tree.DeleteVersionsTo(1)
 	tree.DeleteVersionsTo(2)
@@ -1049,6 +1057,8 @@ func TestVersionedCheckpointsSpecialCase7(_ *testing.T) {
 
 	tree.Set([]byte("A"), []byte("tWQgbFCY"))
 	tree.SaveVersion()
+
+	tree.ndb.waitAsyncWrite()
 
 	tree.DeleteVersionsTo(4)
 
@@ -1199,6 +1209,8 @@ func TestOrphans(t *testing.T) {
 		_, _, err := tree.SaveVersion()
 		require.NoError(err, "SaveVersion should not error")
 	}
+
+	tree.ndb.waitAsyncWrite()
 
 	for v := 1; v < NUMVERSIONS; v++ {
 		err := tree.DeleteVersionsTo(int64(v))

--- a/tree_test.go
+++ b/tree_test.go
@@ -610,6 +610,9 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	tree.Set([]byte("key2"), []byte("val0"))
 	tree.SaveVersion()
 
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
+
 	leafNodes, err := tree.ndb.leafNodes()
 	require.Nil(t, err)
 	require.Len(t, leafNodes, 3)
@@ -619,6 +622,9 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	tree.Set([]byte("key3"), []byte("val1"))
 	tree.SaveVersion()
 
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
+
 	leafNodes, err = tree.ndb.leafNodes()
 	require.Nil(t, err)
 	require.Len(t, leafNodes, 6)
@@ -627,6 +633,9 @@ func TestVersionedTreeVersionDeletingEfficiency(t *testing.T) {
 	tree.Remove([]byte("key1"))
 	tree.Set([]byte("key2"), []byte("val2"))
 	tree.SaveVersion()
+
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
 
 	leafNodes, err = tree.ndb.leafNodes()
 	require.Nil(t, err)

--- a/tree_test.go
+++ b/tree_test.go
@@ -198,7 +198,7 @@ func TestVersionedRandomTreeSmallKeys(t *testing.T) {
 	}
 	singleVersionTree.SaveVersion()
 
-	// tree.ndb.asyncWrite()
+	tree.ndb.waitAsyncWrite()
 	for i := 1; i < versions; i++ {
 		tree.DeleteVersionsTo(int64(i))
 	}
@@ -1415,6 +1415,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 		require.NoError(err, "SaveVersion should not fail")
 	}
 
+	tree.ndb.waitAsyncWrite()
 	tree = NewMutableTree(mdb, 0, false, log.NewNopLogger())
 	require.Error(tree.LoadVersionForOverwriting(int64(maxLength * 2)))
 
@@ -1441,6 +1442,7 @@ func TestLoadVersionForOverwriting(t *testing.T) {
 	require.NoError(err, "SaveVersion should not fail, overwrite was allowed")
 
 	// Reload tree at version 50, the latest tree version is 52
+	tree.ndb.waitAsyncWrite()
 	tree = NewMutableTree(mdb, 0, false, log.NewNopLogger())
 	_, err = tree.LoadVersion(int64(maxLength / 2))
 	require.NoError(err, "LoadVersion should not fail")
@@ -1631,6 +1633,7 @@ func TestIterate_ImmutableTree_Version1(t *testing.T) {
 	_, _, err := tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	immutableTree, err := tree.GetImmutable(1)
 	require.NoError(t, err)
 
@@ -1648,6 +1651,7 @@ func TestIterate_ImmutableTree_Version2(t *testing.T) {
 	_, _, err = tree.SaveVersion()
 	require.NoError(t, err)
 
+	tree.ndb.waitAsyncWrite()
 	immutableTree, err := tree.GetImmutable(2)
 	require.NoError(t, err)
 
@@ -1817,15 +1821,15 @@ func TestNodeCacheStatisic(t *testing.T) {
 			cacheSize:              numKeyVals,
 			expectFastCacheHitCnt:  numKeyVals,
 			expectFastCacheMissCnt: 0,
-			expectCacheHitCnt:      0,
-			expectCacheMissCnt:     1,
+			expectCacheHitCnt:      1,
+			expectCacheMissCnt:     0,
 		},
 		"without_cache": {
 			cacheSize:              0,
 			expectFastCacheHitCnt:  100000, // this value is hardcoded in nodedb for fast cache.
 			expectFastCacheMissCnt: 0,
-			expectCacheHitCnt:      0,
-			expectCacheMissCnt:     1,
+			expectCacheHitCnt:      1,
+			expectCacheMissCnt:     0,
 		},
 	}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1555,6 +1555,8 @@ func TestLoadVersionForOverwritingCase2(t *testing.T) {
 	_, _, err = tree.SaveVersion()
 	require.NoError(err, "SaveVersion should not fail")
 
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
 	err = tree.DeleteVersionsTo(1)
 	require.NoError(err, "DeleteVersion should not fail")
 
@@ -1583,6 +1585,8 @@ func TestLoadVersionForOverwritingCase3(t *testing.T) {
 
 	removedNodes := []*Node{}
 
+	tree.ndb.waitAsyncWrite()
+	tree.ndb.startAsyncWrite()
 	nodes, err := tree.ndb.nodes()
 	require.NoError(err)
 	for _, n := range nodes {

--- a/tree_test.go
+++ b/tree_test.go
@@ -247,6 +247,7 @@ func TestVersionedRandomTreeSmallKeysRandomDeletes(t *testing.T) {
 	}
 	singleVersionTree.SaveVersion()
 
+	tree.ndb.waitAsyncWrite()
 	for _, i := range iavlrand.RandPerm(versions - 1) {
 		tree.DeleteVersionsTo(int64(i + 1))
 	}


### PR DESCRIPTION
closes: #819

- Refactored writing nodes and fastnodes asynchronously
- Removed the `commitGap` since we have a `flusherBatch`