### PR TITLE
fix: protect the concurrent readers using ImmutableTree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [#815](https://github.com/cosmos/iavl/pull/815) `NewMutableTreeWithOpts` was removed in favour of accepting options via a variadic in `NewMutableTree`
 - [#815](https://github.com/cosmos/iavl/pull/815) `NewImmutableTreeWithOpts` is removed in favour of accepting options via a variadic in `NewImmutableTree`
 - [#646](https://github.com/cosmos/iavl/pull/646) Remove the `DeleteVersion`, `DeleteVersions`, `DeleteVersionsRange` and introduce a new endpoint of `DeleteVersionsTo` instead
+- [#]() Protect the concurrent readers using ImmutableTree
 
 ## 0.20.0 (March 14, 2023)
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -2,11 +2,14 @@ package iavl
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"cosmossdk.io/log"
 	dbm "github.com/cosmos/cosmos-db"
 )
+
+var _ io.Closer = (*ImmutableTree)(nil)
 
 // ImmutableTree contains the immutable tree at a given version. It is typically created by calling
 // MutableTree.GetImmutable(), in which case the returned tree is safe for concurrent access as
@@ -41,6 +44,11 @@ func NewImmutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, lg 
 		ndb:                    newNodeDB(db, cacheSize, opts, lg),
 		skipFastStorageUpgrade: skipFastStorageUpgrade,
 	}
+}
+
+func (t *ImmutableTree) Close() error {
+	t.ndb.decrVersionReaders(t.version)
+	return nil
 }
 
 // String returns a string representation of Tree.

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -638,6 +638,7 @@ func (tree *MutableTree) GetImmutable(version int64) (*ImmutableTree, error) {
 		}
 	}
 
+	tree.ndb.incrVersionReaders(version)
 	return &ImmutableTree{
 		root:                   root,
 		ndb:                    tree.ndb,


### PR DESCRIPTION
Solution:
- incrVersionReader when creating the ImmutableTree.
- the caller should close the tree when done with it.