### PR TITLE
Speedup key formatting

### DIFF
--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -1,0 +1,41 @@
+package keyformat
+
+import "encoding/binary"
+
+// This file builds some dedicated key formatters for what appears in benchmarks.
+
+// Prefixes a single byte before a 32 byte hash.
+type FastPrefixFormatter struct {
+	prefix      byte
+	length      int
+	prefixSlice []byte
+}
+
+func NewFastPrefixFormatter(prefix byte, length int) *FastPrefixFormatter {
+	return &FastPrefixFormatter{prefix: prefix, length: length, prefixSlice: []byte{prefix}}
+}
+
+func (f *FastPrefixFormatter) Key(bz []byte) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	copy(key[1:], bz)
+	return key
+}
+
+func (f *FastPrefixFormatter) Scan(key []byte, a interface{}) {
+	scan(a, key[1:])
+}
+
+func (f *FastPrefixFormatter) KeyInt64(bz int64) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	binary.BigEndian.PutUint64(key[1:], uint64(bz))
+	return key
+}
+
+func (f *FastPrefixFormatter) Prefix() []byte {
+	return f.prefixSlice
+}
+func (f *FastPrefixFormatter) Length() int {
+	return 1 + f.length
+}

--- a/node.go
+++ b/node.go
@@ -57,11 +57,15 @@ func GetRootKey(version int64) []byte {
 
 // Node represents a node in a Tree.
 type Node struct {
-	key           []byte
-	value         []byte
-	hash          []byte
-	nodeKey       *NodeKey
-	leftNodeKey   []byte
+	key     []byte
+	value   []byte
+	hash    []byte
+	nodeKey *NodeKey
+	// Legacy: LeftNodeHash
+	// v1: Left node ptr via Version/key
+	leftNodeKey []byte
+	// Legacy: RightNodeHash
+	// v1: Right node ptr via Version/key
 	rightNodeKey  []byte
 	size          int64
 	leftNode      *Node

--- a/nodedb.go
+++ b/nodedb.go
@@ -40,10 +40,10 @@ const (
 var (
 	// All new node keys are prefixed with the byte 's'. This ensures no collision is
 	// possible with the legacy nodes, and makes them easier to traverse. They are indexed by the version and the local nonce.
-	nodeKeyFormat = keyformat.NewKeyFormat('s', int64Size+int32Size) // s<version><nonce>
+	nodeKeyFormat = keyformat.NewFastPrefixFormatter('s', int64Size+int32Size) // s<version><nonce>
 
 	// This is only used for the iteration purpose.
-	nodeKeyPrefixFormat = keyformat.NewKeyFormat('s', int64Size) // s<version>
+	nodeKeyPrefixFormat = keyformat.NewFastPrefixFormatter('s', int64Size) // s<version>
 
 	// Key Format for making reads and iterates go through a data-locality preserving db.
 	// The value at an entry will list what version it was written to.
@@ -58,7 +58,7 @@ var (
 	metadataKeyFormat = keyformat.NewKeyFormat('m', 0) // m<keystring>
 
 	// All legacy node keys are prefixed with the byte 'n'.
-	legacyNodeKeyFormat = keyformat.NewKeyFormat('n', hashSize) // n<hash>
+	legacyNodeKeyFormat = keyformat.NewFastPrefixFormatter('n', hashSize) // n<hash>
 
 	// All legacy orphan keys are prefixed with the byte 'o'.
 	legacyOrphanKeyFormat = keyformat.NewKeyFormat('o', int64Size, int64Size, hashSize) // o<last-version><first-version><hash>
@@ -520,7 +520,7 @@ func (ndb *nodeDB) DeleteVersionsFrom(fromVersion int64) error {
 	}
 
 	// Delete the nodes for new format
-	err = ndb.traverseRange(nodeKeyPrefixFormat.Key(fromVersion), nodeKeyPrefixFormat.Key(latest+1), func(k, v []byte) error {
+	err = ndb.traverseRange(nodeKeyPrefixFormat.KeyInt64(fromVersion), nodeKeyPrefixFormat.KeyInt64(latest+1), func(k, v []byte) error {
 		return ndb.batch.Delete(k)
 	})
 
@@ -600,7 +600,7 @@ func (ndb *nodeDB) nodeKey(nk []byte) []byte {
 }
 
 func (ndb *nodeDB) nodeKeyPrefix(version int64) []byte {
-	return nodeKeyPrefixFormat.Key(version)
+	return nodeKeyPrefixFormat.KeyInt64(version)
 }
 
 func (ndb *nodeDB) fastNodeKey(key []byte) []byte {
@@ -696,8 +696,8 @@ func (ndb *nodeDB) getLatestVersion() (int64, error) {
 	}
 
 	itr, err := ndb.db.ReverseIterator(
-		nodeKeyPrefixFormat.Key(int64(1)),
-		nodeKeyPrefixFormat.Key(int64(math.MaxInt64)),
+		nodeKeyPrefixFormat.KeyInt64(int64(1)),
+		nodeKeyPrefixFormat.KeyInt64(int64(math.MaxInt64)),
 	)
 	if err != nil {
 		return 0, err
@@ -1016,7 +1016,7 @@ func isReferenceToRoot(bz []byte) bool {
 func (ndb *nodeDB) traverseNodes(fn func(node *Node) error) error {
 	nodes := []*Node{}
 
-	if err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	if err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		if isReferenceToRoot(value) {
 			return nil
 		}
@@ -1099,7 +1099,7 @@ func (ndb *nodeDB) String() (string, error) {
 
 	index := 0
 
-	err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		fmt.Fprintf(buf, "%s: %x\n", key, value)
 		return nil
 	})


### PR DESCRIPTION
This speeds up key formatting, which is by no means the bottleneck, but appeared to be 0.5% of the time of some Osmosis mainnet sync pprof's on IAVL v0 and v1