### PR TITLE
perf: Avoid making an extra heap copy in DecodeBytes

### DIFF
--- a/fastnode/fast_node.go
+++ b/fastnode/fast_node.go
@@ -30,6 +30,7 @@ func NewNode(key []byte, value []byte, version int64) *Node {
 }
 
 // DeserializeNode constructs an *FastNode from an encoded byte slice.
+// It assumes we do not mutate this input []byte.
 func DeserializeNode(key []byte, buf []byte) (*Node, error) {
 	ver, n, err := encoding.DecodeVarint(buf)
 	if err != nil {

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -30,6 +30,7 @@ var uvarintPool = &sync.Pool{
 
 // decodeBytes decodes a varint length-prefixed byte slice, returning it along with the number
 // of input bytes read.
+// Assumes bz will not be mutated.
 func DecodeBytes(bz []byte) ([]byte, int, error) {
 	s, n, err := DecodeUvarint(bz)
 	if err != nil {
@@ -51,9 +52,9 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	bz2 := make([]byte, size)
-	copy(bz2, bz[n:end])
-	return bz2, end, nil
+	// bz2 := make([]byte, size)
+	// copy(bz2, bz[n:end])
+	return bz[n:end], end, nil
 }
 
 // decodeUvarint decodes a varint-encoded unsigned integer from a byte slice, returning it and the

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -52,8 +52,6 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	// bz2 := make([]byte, size)
-	// copy(bz2, bz[n:end])
 	return bz[n:end], end, nil
 }
 


### PR DESCRIPTION
Deserializing bytes right now is making a new heap copy of the slice. In IAVL v1, with legacy nodes, over a 100 block period this appeared to be `0.3%` of the CPU time. (Plus heap / memory pressure)

This is only needed if the input bytes are mutated, but this is not the case in any usage of this, as each read is coming from a new `GetNode` or cache result. GetNode returns new heap-data for the value, and the cache entries do not mutate. Hence we can save on CPU time + heap pressure with this.