### PR TITLE
fix: iavl live migration of orphan nodes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,16 +15,8 @@ jobs:
       - uses: actions/setup-go@v2.2.0
         with:
           go-version: 1.21
-      - uses: technote-space/get-diff-action@v6.0.1
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
           args: --out-format=tab
-        if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           go-version: 1.21
       - name: golangci-lint
-        run: make lint-all
+        run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,4 @@ jobs:
         with:
           go-version: 1.21
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: latest
-          args: --out-format=tab
+        run: make lint-all

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '^1.20.0'
+          go-version: "^1.21.0"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,10 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2.2.0
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: 🐿 Setup Golang
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21
       - name: golangci-lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,11 +12,19 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v2.2.0
         with:
-          go-version: "^1.21.0"
+          go-version: 1.20
+      - uses: technote-space/get-diff-action@v6.0.1
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/**.go
+            go.mod
+            go.sum
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: latest
+          args: --out-format=tab
+        if: env.GIT_DIFF

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2.2.0
         with:
-          go-version: 1.20
+          go-version: 1.21
       - uses: technote-space/get-diff-action@v6.0.1
         id: git_diff
         with:

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,6 @@ lint-fix:
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version)
 	@$(golangci_lint_cmd) run --fix --out-format=tab --issues-exit-code=0
 
-lint-all:
-	@echo "--> Running linter"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
-	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md"
-
 # bench is the basic tests that shouldn't crash an aws instance
 bench:
 	cd benchmarks && \

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,11 @@ lint-fix:
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version)
 	@$(golangci_lint_cmd) run --fix --out-format=tab --issues-exit-code=0
 
+lint-all:
+	@echo "--> Running linter"
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint run --timeout=10m
+	@docker run -v $(PWD):/workdir ghcr.io/igorshubovych/markdownlint-cli:latest "**/*.md"
+
 # bench is the basic tests that shouldn't crash an aws instance
 bench:
 	cd benchmarks && \

--- a/fastnode/fast_node.go
+++ b/fastnode/fast_node.go
@@ -30,6 +30,7 @@ func NewNode(key []byte, value []byte, version int64) *Node {
 }
 
 // DeserializeNode constructs an *FastNode from an encoded byte slice.
+// It assumes we do not mutate this input []byte.
 func DeserializeNode(key []byte, buf []byte) (*Node, error) {
 	ver, n, err := encoding.DecodeVarint(buf)
 	if err != nil {

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -30,6 +30,7 @@ var uvarintPool = &sync.Pool{
 
 // decodeBytes decodes a varint length-prefixed byte slice, returning it along with the number
 // of input bytes read.
+// Assumes bz will not be mutated.
 func DecodeBytes(bz []byte) ([]byte, int, error) {
 	s, n, err := DecodeUvarint(bz)
 	if err != nil {
@@ -51,9 +52,9 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	bz2 := make([]byte, size)
-	copy(bz2, bz[n:end])
-	return bz2, end, nil
+	// bz2 := make([]byte, size)
+	// copy(bz2, bz[n:end])
+	return bz[n:end], end, nil
 }
 
 // decodeUvarint decodes a varint-encoded unsigned integer from a byte slice, returning it and the

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -52,8 +52,6 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	// bz2 := make([]byte, size)
-	// copy(bz2, bz[n:end])
 	return bz[n:end], end, nil
 }
 

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -97,6 +97,23 @@ func EncodeBytes(w io.Writer, bz []byte) error {
 	return err
 }
 
+var hashLenBz []byte
+
+func init() {
+	hashLenBz = make([]byte, 1)
+	binary.PutUvarint(hashLenBz, 32)
+}
+
+// Encode 32 byte long hash
+func Encode32BytesHash(w io.Writer, bz []byte) error {
+	_, err := w.Write(hashLenBz)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(bz)
+	return err
+}
+
 // encodeBytesSlice length-prefixes the byte slice and returns it.
 func EncodeBytesSlice(bz []byte) ([]byte, error) {
 	buf := bufPool.Get().(*bytes.Buffer)

--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -36,6 +36,7 @@ func (f *FastPrefixFormatter) KeyInt64(bz int64) []byte {
 func (f *FastPrefixFormatter) Prefix() []byte {
 	return f.prefixSlice
 }
+
 func (f *FastPrefixFormatter) Length() int {
 	return 1 + f.length
 }

--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -1,0 +1,41 @@
+package keyformat
+
+import "encoding/binary"
+
+// This file builds some dedicated key formatters for what appears in benchmarks.
+
+// Prefixes a single byte before a 32 byte hash.
+type FastPrefixFormatter struct {
+	prefix      byte
+	length      int
+	prefixSlice []byte
+}
+
+func NewFastPrefixFormatter(prefix byte, length int) *FastPrefixFormatter {
+	return &FastPrefixFormatter{prefix: prefix, length: length, prefixSlice: []byte{prefix}}
+}
+
+func (f *FastPrefixFormatter) Key(bz []byte) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	copy(key[1:], bz)
+	return key
+}
+
+func (f *FastPrefixFormatter) Scan(key []byte, a interface{}) {
+	scan(a, key[1:])
+}
+
+func (f *FastPrefixFormatter) KeyInt64(bz int64) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	binary.BigEndian.PutUint64(key[1:], uint64(bz))
+	return key
+}
+
+func (f *FastPrefixFormatter) Prefix() []byte {
+	return f.prefixSlice
+}
+func (f *FastPrefixFormatter) Length() int {
+	return 1 + f.length
+}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -267,10 +267,10 @@ func (tree *MutableTree) set(key []byte, value []byte) (updated bool, err error)
 func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
+	fmt.Println("Recursive Set cur_node=", string(node.key))
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
 	}
-	fmt.Println("Recursive Set", node.key)
 	node, err = node.clone(tree)
 	if err != nil {
 		return nil, false, err
@@ -313,7 +313,7 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	fmt.Println("Recursive Set Leaf", node.key)
+	fmt.Println("Recursive Set Leaf, leaf node key=", string(node.key))
 	version := tree.version + 1
 	if !tree.skipFastStorageUpgrade {
 		tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
@@ -350,10 +350,10 @@ func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) 
 func (tree *MutableTree) recursiveSetLegacy(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
+	fmt.Println("Recursive Set Legacy cur_node=", string(node.key))
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
 	}
-	fmt.Println("Recursive Set Legacy", string(node.key))
 	node, err = node.cloneNoChildFetch(tree)
 	if err != nil {
 		return nil, false, err
@@ -425,7 +425,7 @@ func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 // - the removed value
 func (tree *MutableTree) recursiveRemove(node *Node, key []byte) (newSelf *Node, newKey []byte, newValue []byte, removed bool, err error) {
 	tree.logger.Debug("recursiveRemove", "node", node, "key", key)
-	fmt.Println("Recursive remove", string(node.key))
+	fmt.Println("Recursive remove cur_node=", string(node.key))
 	if node.isLeaf() {
 
 		if bytes.Equal(key, node.key) {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -161,7 +161,6 @@ func (tree *MutableTree) String() (string, error) {
 // to slices stored within IAVL. It returns true when an existing value was
 // updated, while false means it was a new key.
 func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
-	fmt.Println("Set", key)
 	updated, err = tree.set(key, value)
 	if err != nil {
 		return false, err
@@ -267,7 +266,6 @@ func (tree *MutableTree) set(key []byte, value []byte) (updated bool, err error)
 func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	fmt.Println("Recursive Set cur_node=", string(node.key))
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
 	}
@@ -313,7 +311,6 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	fmt.Println("Recursive Set Leaf, leaf node key=", string(node.key))
 	version := tree.version + 1
 	if !tree.skipFastStorageUpgrade {
 		tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
@@ -350,7 +347,6 @@ func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) 
 func (tree *MutableTree) recursiveSetLegacy(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	fmt.Println("Recursive Set Legacy cur_node=", string(node.key))
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
 	}
@@ -400,7 +396,6 @@ func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 	if tree.root == nil {
 		return nil, false, nil
 	}
-	fmt.Println("Remove", string(key))
 	newRoot, _, value, removed, err := tree.recursiveRemove(tree.root, key)
 	if err != nil {
 		return nil, false, err
@@ -425,9 +420,7 @@ func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 // - the removed value
 func (tree *MutableTree) recursiveRemove(node *Node, key []byte) (newSelf *Node, newKey []byte, newValue []byte, removed bool, err error) {
 	tree.logger.Debug("recursiveRemove", "node", node, "key", key)
-	fmt.Println("Recursive remove cur_node=", string(node.key))
 	if node.isLeaf() {
-
 		if bytes.Equal(key, node.key) {
 			return nil, nil, node.value, true, nil
 		}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -161,6 +161,7 @@ func (tree *MutableTree) String() (string, error) {
 // to slices stored within IAVL. It returns true when an existing value was
 // updated, while false means it was a new key.
 func (tree *MutableTree) Set(key, value []byte) (updated bool, err error) {
+	fmt.Println("Set", key)
 	updated, err = tree.set(key, value)
 	if err != nil {
 		return false, err
@@ -269,62 +270,130 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 	version := tree.version + 1
 
 	if node.isLeaf() {
-		if !tree.skipFastStorageUpgrade {
-			tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
+		return tree.recursiveSetLeaf(node, key, value)
+	}
+	fmt.Println("Recursive Set", node.key)
+	node, err = node.clone(tree)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if bytes.Compare(key, node.key) < 0 {
+		if len(node.leftNodeKey) == 32 {
+			node.leftNode, updated, err = tree.recursiveSetLegacy(node.leftNode, key, value)
+		} else {
+			node.leftNode, updated, err = tree.recursiveSet(node.leftNode, key, value)
 		}
-		switch bytes.Compare(key, node.key) {
-		case -1: // setKey < leafKey
-			return &Node{
-				key:           node.key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      NewNode(key, value),
-				rightNode:     node,
-			}, false, nil
-		case 1: // setKey > leafKey
-			return &Node{
-				key:           key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      node,
-				rightNode:     NewNode(key, value),
-			}, false, nil
-		default:
-			return NewNode(key, value), true, nil
+		if err != nil {
+			return nil, updated, err
 		}
 	} else {
-		node, err = node.clone(tree)
-		if err != nil {
-			return nil, false, err
-		}
-
-		if bytes.Compare(key, node.key) < 0 {
-			node.leftNode, updated, err = tree.recursiveSet(node.leftNode, key, value)
-			if err != nil {
-				return nil, updated, err
-			}
+		if len(node.rightNodeKey) == 32 {
+			node.rightNode, updated, err = tree.recursiveSetLegacy(node.rightNode, key, value)
 		} else {
 			node.rightNode, updated, err = tree.recursiveSet(node.rightNode, key, value)
-			if err != nil {
-				return nil, updated, err
-			}
 		}
-
-		if updated {
-			return node, updated, nil
-		}
-		err = node.calcHeightAndSize(tree.ImmutableTree)
 		if err != nil {
-			return nil, false, err
+			return nil, updated, err
 		}
-		newNode, err := tree.balance(node)
-		if err != nil {
-			return nil, false, err
-		}
-		return newNode, updated, err
 	}
+
+	if updated {
+		return node, updated, nil
+	}
+	err = node.calcHeightAndSize(tree.ImmutableTree)
+	if err != nil {
+		return nil, false, err
+	}
+	newNode, err := tree.balance(node)
+	if err != nil {
+		return nil, false, err
+	}
+	return newNode, updated, err
+}
+
+func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (
+	newSelf *Node, updated bool, err error,
+) {
+	fmt.Println("Recursive Set Leaf", node.key)
+	version := tree.version + 1
+	if !tree.skipFastStorageUpgrade {
+		tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
+	}
+	switch bytes.Compare(key, node.key) {
+	case -1: // setKey < leafKey
+		return &Node{
+			key:           node.key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      NewNode(key, value),
+			rightNode:     node,
+		}, false, nil
+	case 1: // setKey > leafKey
+		return &Node{
+			key:           key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      node,
+			rightNode:     NewNode(key, value),
+		}, false, nil
+	default:
+		return NewNode(key, value), true, nil
+	}
+}
+
+// recursiveSetLegacy is the same as recursiveSet but takes an optimization where
+// if you are updating an existing leaf, you do not need to get both children, you only need one child.
+//
+// This operates on the assumption that when recursiveSet enters a legacy node,
+// all of the legacy nodes children will be legacy nodes.
+func (tree *MutableTree) recursiveSetLegacy(node *Node, key []byte, value []byte) (
+	newSelf *Node, updated bool, err error,
+) {
+	if node.isLeaf() {
+		return tree.recursiveSetLeaf(node, key, value)
+	}
+	fmt.Println("Recursive Set Legacy", string(node.key))
+	node, err = node.cloneNoChildFetch(tree)
+	if err != nil {
+		return nil, false, err
+	}
+
+	recurseLeft := false
+	if bytes.Compare(key, node.key) < 0 {
+		recurseLeft = true
+	}
+	child, err := node.fetchOneChild(tree, recurseLeft)
+	if err != nil {
+		return nil, false, err
+	}
+
+	newChild, updated, err := tree.recursiveSetLegacy(child, key, value)
+	if err != nil {
+		return nil, updated, err
+	}
+	if recurseLeft {
+		node.leftNode = newChild
+	} else {
+		node.rightNode = newChild
+	}
+
+	if updated {
+		return node, updated, nil
+	}
+	node.fetchOneChild(tree, !recurseLeft)
+
+	err = node.calcHeightAndSize(tree.ImmutableTree)
+	if err != nil {
+		return nil, false, err
+	}
+	newNode, err := tree.balance(node)
+	if err != nil {
+		return nil, false, err
+	}
+	return newNode, updated, err
 }
 
 // Remove removes a key from the working tree. The given key byte slice should not be modified
@@ -333,6 +402,7 @@ func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 	if tree.root == nil {
 		return nil, false, nil
 	}
+	fmt.Println("Remove", string(key))
 	newRoot, _, value, removed, err := tree.recursiveRemove(tree.root, key)
 	if err != nil {
 		return nil, false, err
@@ -357,7 +427,9 @@ func (tree *MutableTree) Remove(key []byte) ([]byte, bool, error) {
 // - the removed value
 func (tree *MutableTree) recursiveRemove(node *Node, key []byte) (newSelf *Node, newKey []byte, newValue []byte, removed bool, err error) {
 	tree.logger.Debug("recursiveRemove", "node", node, "key", key)
+	fmt.Println("Recursive remove", string(node.key))
 	if node.isLeaf() {
+
 		if bytes.Equal(key, node.key) {
 			return nil, nil, node.value, true, nil
 		}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -350,7 +350,7 @@ func (tree *MutableTree) recursiveSetLegacy(node *Node, key []byte, value []byte
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
 	}
-	node, err = node.cloneNoChildFetch(tree)
+	node, err = node.cloneNoChildFetch()
 	if err != nil {
 		return nil, false, err
 	}
@@ -377,7 +377,10 @@ func (tree *MutableTree) recursiveSetLegacy(node *Node, key []byte, value []byte
 	if updated {
 		return node, updated, nil
 	}
-	node.fetchOneChild(tree, !recurseLeft)
+	_, err = node.fetchOneChild(tree, !recurseLeft)
+	if err != nil {
+		return nil, false, err
+	}
 
 	err = node.calcHeightAndSize(tree.ImmutableTree)
 	if err != nil {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -266,34 +266,8 @@ func (tree *MutableTree) set(key []byte, value []byte) (updated bool, err error)
 func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	version := tree.version + 1
-
 	if node.isLeaf() {
-		if !tree.skipFastStorageUpgrade {
-			tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
-		}
-		switch bytes.Compare(key, node.key) {
-		case -1: // setKey < leafKey
-			return &Node{
-				key:           node.key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      NewNode(key, value),
-				rightNode:     node,
-			}, false, nil
-		case 1: // setKey > leafKey
-			return &Node{
-				key:           key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      node,
-				rightNode:     NewNode(key, value),
-			}, false, nil
-		default:
-			return NewNode(key, value), true, nil
-		}
+		return tree.recursiveSetLeaf(node, key, value)
 	} else {
 		node, err = node.clone(tree)
 		if err != nil {
@@ -324,6 +298,37 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 			return nil, false, err
 		}
 		return newNode, updated, err
+	}
+}
+
+func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (
+	newSelf *Node, updated bool, err error,
+) {
+	version := tree.version + 1
+	if !tree.skipFastStorageUpgrade {
+		tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
+	}
+	switch bytes.Compare(key, node.key) {
+	case -1: // setKey < leafKey
+		return &Node{
+			key:           node.key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      NewNode(key, value),
+			rightNode:     node,
+		}, false, nil
+	case 1: // setKey > leafKey
+		return &Node{
+			key:           key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      node,
+			rightNode:     NewNode(key, value),
+		}, false, nil
+	default:
+		return NewNode(key, value), true, nil
 	}
 }
 

--- a/node.go
+++ b/node.go
@@ -328,6 +328,9 @@ func (node *Node) cloneNoChildFetch(tree *MutableTree) (*Node, error) {
 	if node.isLeaf() {
 		return nil, ErrCloneLeafNode
 	}
+	// match compatability with old by clearing original node's pointer ref's. I don't really get why this is needed.
+	leftNode, rightNode := node.leftNode, node.rightNode
+	node.leftNode, node.rightNode = nil, nil
 
 	return &Node{
 		key:           node.key,
@@ -335,6 +338,8 @@ func (node *Node) cloneNoChildFetch(tree *MutableTree) (*Node, error) {
 		size:          node.size,
 		hash:          nil,
 		nodeKey:       nil,
+		leftNode:      leftNode,
+		rightNode:     rightNode,
 		leftNodeKey:   node.leftNodeKey,
 		rightNodeKey:  node.rightNodeKey,
 	}, nil

--- a/node.go
+++ b/node.go
@@ -329,9 +329,11 @@ func (node *Node) cloneNoChildFetch(tree *MutableTree) (*Node, error) {
 		return nil, ErrCloneLeafNode
 	}
 	// match compatability with old by clearing original node's pointer ref's. I don't really get why this is needed.
-	leftNode, rightNode := node.leftNode, node.rightNode
-	node.leftNode, node.rightNode = nil, nil
-
+	var leftNode, rightNode *Node
+	if node.nodeKey != nil {
+		leftNode, rightNode = node.leftNode, node.rightNode
+		node.leftNode, node.rightNode = nil, nil
+	}
 	return &Node{
 		key:           node.key,
 		subtreeHeight: node.subtreeHeight,

--- a/node.go
+++ b/node.go
@@ -324,11 +324,11 @@ func (node *Node) clone(tree *MutableTree) (*Node, error) {
 }
 
 // cloneNoChildFetch clones a node without fetching its children.
-func (node *Node) cloneNoChildFetch(tree *MutableTree) (*Node, error) {
+func (node *Node) cloneNoChildFetch() (*Node, error) {
 	if node.isLeaf() {
 		return nil, ErrCloneLeafNode
 	}
-	// match compatability with old by clearing original node's pointer ref's. I don't really get why this is needed.
+	// match compatibility with old by clearing original node's pointer ref's. I don't really get why this is needed.
 	var leftNode, rightNode *Node
 	if node.nodeKey != nil {
 		leftNode, rightNode = node.leftNode, node.rightNode

--- a/nodedb.go
+++ b/nodedb.go
@@ -443,7 +443,7 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 					counter += 1
 					if counter == 1000 {
 						counter = 0
-						time.Sleep(100 * time.Millisecond)
+						time.Sleep(1000 * time.Millisecond)
 						fmt.Println("IAVL sleep happening")
 					}
 					return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))

--- a/nodedb.go
+++ b/nodedb.go
@@ -420,7 +420,7 @@ func (ndb *nodeDB) deleteLegacyNodes(version int64, nk []byte) error {
 	return ndb.batch.Delete(ndb.legacyNodeKey(nk))
 }
 
-var isDeletingLegacyVersionsMutex *sync.Mutex
+var isDeletingLegacyVersionsMutex *sync.Mutex = &sync.Mutex{}
 var isDeletingLegacyVersions bool = false
 
 // deleteLegacyVersions deletes all legacy versions from disk.

--- a/nodedb.go
+++ b/nodedb.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"cosmossdk.io/log"
 	dbm "github.com/cosmos/cosmos-db"
@@ -470,9 +471,39 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 	ndb.legacyLatestVersion = -1
 
 	// Delete all orphan nodes of the legacy versions
-	return ndb.traversePrefix(legacyOrphanKeyFormat.Key(), func(key, value []byte) error {
-		return ndb.batch.Delete(key)
-	})
+	go func() {
+		if err := ndb.deleteOrphans(); err != nil {
+			ndb.logger.Error("failed to clean legacy orphans", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+// deleteOrphans cleans all legacy orphans from the nodeDB.
+func (ndb *nodeDB) deleteOrphans() error {
+	itr, err := dbm.IteratePrefix(ndb.db, legacyOrphanKeyFormat.Key())
+	if err != nil {
+		return err
+	}
+	defer itr.Close()
+
+	count := 0
+	for ; itr.Valid(); itr.Next() {
+		if err := ndb.batch.Delete(itr.Key()); err != nil {
+			return err
+		}
+
+		// Sleep for a while to avoid blocking the main thread i/o.
+		count++
+		if count > 1000 {
+			count = 0
+			time.Sleep(100 * time.Millisecond)
+		}
+
+	}
+
+	return nil
 }
 
 // DeleteVersionsFrom permanently deletes all tree versions from the given version upwards.

--- a/nodedb.go
+++ b/nodedb.go
@@ -41,10 +41,10 @@ const (
 var (
 	// All new node keys are prefixed with the byte 's'. This ensures no collision is
 	// possible with the legacy nodes, and makes them easier to traverse. They are indexed by the version and the local nonce.
-	nodeKeyFormat = keyformat.NewKeyFormat('s', int64Size+int32Size) // s<version><nonce>
+	nodeKeyFormat = keyformat.NewFastPrefixFormatter('s', int64Size+int32Size) // s<version><nonce>
 
 	// This is only used for the iteration purpose.
-	nodeKeyPrefixFormat = keyformat.NewKeyFormat('s', int64Size) // s<version>
+	nodeKeyPrefixFormat = keyformat.NewFastPrefixFormatter('s', int64Size) // s<version>
 
 	// Key Format for making reads and iterates go through a data-locality preserving db.
 	// The value at an entry will list what version it was written to.
@@ -59,7 +59,7 @@ var (
 	metadataKeyFormat = keyformat.NewKeyFormat('m', 0) // m<keystring>
 
 	// All legacy node keys are prefixed with the byte 'n'.
-	legacyNodeKeyFormat = keyformat.NewKeyFormat('n', hashSize) // n<hash>
+	legacyNodeKeyFormat = keyformat.NewFastPrefixFormatter('n', hashSize) // n<hash>
 
 	// All legacy orphan keys are prefixed with the byte 'o'.
 	legacyOrphanKeyFormat = keyformat.NewKeyFormat('o', int64Size, int64Size, hashSize) // o<last-version><first-version><hash>
@@ -584,7 +584,7 @@ func (ndb *nodeDB) DeleteVersionsFrom(fromVersion int64) error {
 	}
 
 	// Delete the nodes for new format
-	err = ndb.traverseRange(nodeKeyPrefixFormat.Key(fromVersion), nodeKeyPrefixFormat.Key(latest+1), func(k, v []byte) error {
+	err = ndb.traverseRange(nodeKeyPrefixFormat.KeyInt64(fromVersion), nodeKeyPrefixFormat.KeyInt64(latest+1), func(k, v []byte) error {
 		return ndb.batch.Delete(k)
 	})
 
@@ -664,7 +664,7 @@ func (ndb *nodeDB) nodeKey(nk []byte) []byte {
 }
 
 func (ndb *nodeDB) nodeKeyPrefix(version int64) []byte {
-	return nodeKeyPrefixFormat.Key(version)
+	return nodeKeyPrefixFormat.KeyInt64(version)
 }
 
 func (ndb *nodeDB) fastNodeKey(key []byte) []byte {
@@ -760,8 +760,8 @@ func (ndb *nodeDB) getLatestVersion() (int64, error) {
 	}
 
 	itr, err := ndb.db.ReverseIterator(
-		nodeKeyPrefixFormat.Key(int64(1)),
-		nodeKeyPrefixFormat.Key(int64(math.MaxInt64)),
+		nodeKeyPrefixFormat.KeyInt64(int64(1)),
+		nodeKeyPrefixFormat.KeyInt64(int64(math.MaxInt64)),
 	)
 	if err != nil {
 		return 0, err
@@ -1080,7 +1080,7 @@ func isReferenceToRoot(bz []byte) bool {
 func (ndb *nodeDB) traverseNodes(fn func(node *Node) error) error {
 	nodes := []*Node{}
 
-	if err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	if err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		if isReferenceToRoot(value) {
 			return nil
 		}
@@ -1163,7 +1163,7 @@ func (ndb *nodeDB) String() (string, error) {
 
 	index := 0
 
-	err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		fmt.Fprintf(buf, "%s: %x\n", key, value)
 		return nil
 	})

--- a/nodedb.go
+++ b/nodedb.go
@@ -420,8 +420,10 @@ func (ndb *nodeDB) deleteLegacyNodes(version int64, nk []byte) error {
 	return ndb.batch.Delete(ndb.legacyNodeKey(nk))
 }
 
-var isDeletingLegacyVersionsMutex *sync.Mutex = &sync.Mutex{}
-var isDeletingLegacyVersions = false
+var (
+	isDeletingLegacyVersionsMutex = &sync.Mutex{}
+	isDeletingLegacyVersions      = false
+)
 
 // deleteLegacyVersions deletes all legacy versions from disk.
 func (ndb *nodeDB) deleteLegacyVersions() error {

--- a/nodedb.go
+++ b/nodedb.go
@@ -421,7 +421,7 @@ func (ndb *nodeDB) deleteLegacyNodes(version int64, nk []byte) error {
 }
 
 var isDeletingLegacyVersionsMutex *sync.Mutex = &sync.Mutex{}
-var isDeletingLegacyVersions bool = false
+var isDeletingLegacyVersions = false
 
 // deleteLegacyVersions deletes all legacy versions from disk.
 func (ndb *nodeDB) deleteLegacyVersions() error {
@@ -429,10 +429,9 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 	if isDeletingLegacyVersions {
 		isDeletingLegacyVersionsMutex.Unlock()
 		return nil
-	} else {
-		isDeletingLegacyVersions = true
-		isDeletingLegacyVersionsMutex.Unlock()
 	}
+	isDeletingLegacyVersions = true
+	isDeletingLegacyVersionsMutex.Unlock()
 
 	go func() {
 		defer func() {
@@ -458,7 +457,7 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 			rootKeys = append(rootKeys, itr.Key())
 			if prevVersion > 0 {
 				if err := ndb.traverseOrphans(prevVersion, curVersion, func(orphan *Node) error {
-					counter += 1
+					counter++
 					if counter == 1000 {
 						counter = 0
 						time.Sleep(1000 * time.Millisecond)


### PR DESCRIPTION
This is cherry picks of work from both John Reynolds and Dev to ensure main stays up to date with the iavl v1.0.0 branch we will be using in v21 of Osmosis.

Previously, we would block chain progress on pruning orphan nodes. For a chain like Osmosis, this took upwards of 2 hours. This change allows chain progress to continue, while pruning orphan nodes synchronously. 

As a drive by change, this also fixes the golang linter in this repo.