### PR TITLE
feat(v1.x.x): async pruning of orphan nodes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,11 +12,11 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: 🐿 Setup Golang
+        uses: actions/setup-go@v4
         with:
-          go-version: '^1.20.0'
+          go-version: 1.21
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.51.2
+        run: make lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Improvements
+
+- [#876](https://github.com/cosmos/iavl/pull/876) Make pruning of orphan nodes synchronous.
+
 ## v1.0.0 (October 30, 2023)
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Improvements
 
-- [#876](https://github.com/cosmos/iavl/pull/876) Make pruning of orphan nodes synchronous.
+- [#876](https://github.com/cosmos/iavl/pull/876) Make pruning of legacy orphan nodes asynchronous.
 
 ## v1.0.0 (October 30, 2023)
 

--- a/fastnode/fast_node.go
+++ b/fastnode/fast_node.go
@@ -30,6 +30,7 @@ func NewNode(key []byte, value []byte, version int64) *Node {
 }
 
 // DeserializeNode constructs an *FastNode from an encoded byte slice.
+// It assumes we do not mutate this input []byte.
 func DeserializeNode(key []byte, buf []byte) (*Node, error) {
 	ver, n, err := encoding.DecodeVarint(buf)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/emicklei/dot v1.4.2
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.4
-	google.golang.org/protobuf v1.30.0
 	golang.org/x/crypto v0.12.0
+	google.golang.org/protobuf v1.30.0
 )
 
 require (
@@ -49,8 +49,8 @@ require (
 )
 
 retract (
-	v0.18.0
 	// This version is not used by the Cosmos SDK and adds a maintenance burden.
 	// Use v1.x.x instead.
 	[v0.21.0, v0.21.2]
+	v0.18.0
 )

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -30,6 +30,7 @@ var uvarintPool = &sync.Pool{
 
 // decodeBytes decodes a varint length-prefixed byte slice, returning it along with the number
 // of input bytes read.
+// Assumes bz will not be mutated.
 func DecodeBytes(bz []byte) ([]byte, int, error) {
 	s, n, err := DecodeUvarint(bz)
 	if err != nil {
@@ -51,9 +52,9 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	bz2 := make([]byte, size)
-	copy(bz2, bz[n:end])
-	return bz2, end, nil
+	// bz2 := make([]byte, size)
+	// copy(bz2, bz[n:end])
+	return bz[n:end], end, nil
 }
 
 // decodeUvarint decodes a varint-encoded unsigned integer from a byte slice, returning it and the

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -52,8 +52,6 @@ func DecodeBytes(bz []byte) ([]byte, int, error) {
 	if len(bz) < end {
 		return nil, n, fmt.Errorf("insufficient bytes decoding []byte of length %v", size)
 	}
-	// bz2 := make([]byte, size)
-	// copy(bz2, bz[n:end])
 	return bz[n:end], end, nil
 }
 

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -97,6 +97,23 @@ func EncodeBytes(w io.Writer, bz []byte) error {
 	return err
 }
 
+var hashLenBz []byte
+
+func init() {
+	hashLenBz = make([]byte, 1)
+	binary.PutUvarint(hashLenBz, 32)
+}
+
+// Encode 32 byte long hash
+func Encode32BytesHash(w io.Writer, bz []byte) error {
+	_, err := w.Write(hashLenBz)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(bz)
+	return err
+}
+
 // encodeBytesSlice length-prefixes the byte slice and returns it.
 func EncodeBytesSlice(bz []byte) ([]byte, error) {
 	buf := bufPool.Get().(*bytes.Buffer)

--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -36,6 +36,7 @@ func (f *FastPrefixFormatter) KeyInt64(bz int64) []byte {
 func (f *FastPrefixFormatter) Prefix() []byte {
 	return f.prefixSlice
 }
+
 func (f *FastPrefixFormatter) Length() int {
 	return 1 + f.length
 }

--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -1,0 +1,41 @@
+package keyformat
+
+import "encoding/binary"
+
+// This file builds some dedicated key formatters for what appears in benchmarks.
+
+// Prefixes a single byte before a 32 byte hash.
+type FastPrefixFormatter struct {
+	prefix      byte
+	length      int
+	prefixSlice []byte
+}
+
+func NewFastPrefixFormatter(prefix byte, length int) *FastPrefixFormatter {
+	return &FastPrefixFormatter{prefix: prefix, length: length, prefixSlice: []byte{prefix}}
+}
+
+func (f *FastPrefixFormatter) Key(bz []byte) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	copy(key[1:], bz)
+	return key
+}
+
+func (f *FastPrefixFormatter) Scan(key []byte, a interface{}) {
+	scan(a, key[1:])
+}
+
+func (f *FastPrefixFormatter) KeyInt64(bz int64) []byte {
+	key := make([]byte, 1+f.length)
+	key[0] = f.prefix
+	binary.BigEndian.PutUint64(key[1:], uint64(bz))
+	return key
+}
+
+func (f *FastPrefixFormatter) Prefix() []byte {
+	return f.prefixSlice
+}
+func (f *FastPrefixFormatter) Length() int {
+	return 1 + f.length
+}

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -268,37 +268,36 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 ) {
 	if node.isLeaf() {
 		return tree.recursiveSetLeaf(node, key, value)
-	} else {
-		node, err = node.clone(tree)
-		if err != nil {
-			return nil, false, err
-		}
-
-		if bytes.Compare(key, node.key) < 0 {
-			node.leftNode, updated, err = tree.recursiveSet(node.leftNode, key, value)
-			if err != nil {
-				return nil, updated, err
-			}
-		} else {
-			node.rightNode, updated, err = tree.recursiveSet(node.rightNode, key, value)
-			if err != nil {
-				return nil, updated, err
-			}
-		}
-
-		if updated {
-			return node, updated, nil
-		}
-		err = node.calcHeightAndSize(tree.ImmutableTree)
-		if err != nil {
-			return nil, false, err
-		}
-		newNode, err := tree.balance(node)
-		if err != nil {
-			return nil, false, err
-		}
-		return newNode, updated, err
 	}
+	node, err = node.clone(tree)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if bytes.Compare(key, node.key) < 0 {
+		node.leftNode, updated, err = tree.recursiveSet(node.leftNode, key, value)
+		if err != nil {
+			return nil, updated, err
+		}
+	} else {
+		node.rightNode, updated, err = tree.recursiveSet(node.rightNode, key, value)
+		if err != nil {
+			return nil, updated, err
+		}
+	}
+
+	if updated {
+		return node, updated, nil
+	}
+	err = node.calcHeightAndSize(tree.ImmutableTree)
+	if err != nil {
+		return nil, false, err
+	}
+	newNode, err := tree.balance(node)
+	if err != nil {
+		return nil, false, err
+	}
+	return newNode, updated, err
 }
 
 func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -266,34 +266,8 @@ func (tree *MutableTree) set(key []byte, value []byte) (updated bool, err error)
 func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 	newSelf *Node, updated bool, err error,
 ) {
-	version := tree.version + 1
-
 	if node.isLeaf() {
-		if !tree.skipFastStorageUpgrade {
-			tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
-		}
-		switch bytes.Compare(key, node.key) {
-		case -1: // setKey < leafKey
-			return &Node{
-				key:           node.key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      NewNode(key, value),
-				rightNode:     node,
-			}, false, nil
-		case 1: // setKey > leafKey
-			return &Node{
-				key:           key,
-				subtreeHeight: 1,
-				size:          2,
-				nodeKey:       nil,
-				leftNode:      node,
-				rightNode:     NewNode(key, value),
-			}, false, nil
-		default:
-			return NewNode(key, value), true, nil
-		}
+		return tree.recursiveSetLeaf(node, key, value)
 	} else {
 		node, err = node.clone(tree)
 		if err != nil {
@@ -324,6 +298,37 @@ func (tree *MutableTree) recursiveSet(node *Node, key []byte, value []byte) (
 			return nil, false, err
 		}
 		return newNode, updated, err
+	}
+}
+
+func (tree *MutableTree) recursiveSetLeaf(node *Node, key []byte, value []byte) (
+	newSelf *Node, updated bool, err error,
+) {
+	version := tree.version + 1
+	if !tree.skipFastStorageUpgrade {
+		tree.addUnsavedAddition(key, fastnode.NewNode(key, value, version))
+	}
+	switch bytes.Compare(key, node.key) {
+	case -1: // setKey < leafKey
+		return &Node{
+			key:           node.key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      NewNode(key, value),
+			rightNode:     node,
+		}, false, nil
+	case 1: // setKey > leafKey
+		return &Node{
+			key:           key,
+			subtreeHeight: 1,
+			size:          2,
+			nodeKey:       nil,
+			leftNode:      node,
+			rightNode:     NewNode(key, value),
+		}, false, nil
+	default:
+		return NewNode(key, value), true, nil
 	}
 }
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -443,7 +443,7 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 					counter += 1
 					if counter == 1000 {
 						counter = 0
-						time.Sleep(100 * time.Millisecond)
+						time.Sleep(1000 * time.Millisecond)
 						fmt.Println("IAVL sleep happening")
 					}
 					return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))

--- a/nodedb.go
+++ b/nodedb.go
@@ -420,7 +420,7 @@ func (ndb *nodeDB) deleteLegacyNodes(version int64, nk []byte) error {
 	return ndb.batch.Delete(ndb.legacyNodeKey(nk))
 }
 
-var isDeletingLegacyVersionsMutex *sync.Mutex
+var isDeletingLegacyVersionsMutex *sync.Mutex = &sync.Mutex{}
 var isDeletingLegacyVersions bool = false
 
 // deleteLegacyVersions deletes all legacy versions from disk.

--- a/nodedb.go
+++ b/nodedb.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"cosmossdk.io/log"
 	dbm "github.com/cosmos/cosmos-db"
@@ -470,9 +471,39 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 	ndb.legacyLatestVersion = -1
 
 	// Delete all orphan nodes of the legacy versions
-	return ndb.traversePrefix(legacyOrphanKeyFormat.Key(), func(key, value []byte) error {
-		return ndb.batch.Delete(key)
-	})
+	go func() {
+		if err := ndb.deleteOrphans(); err != nil {
+			ndb.logger.Error("failed to clean legacy orphans", "err", err)
+		}
+	}()
+
+	return nil
+}
+
+// deleteOrphans cleans all legacy orphans from the nodeDB.
+func (ndb *nodeDB) deleteOrphans() error {
+	itr, err := dbm.IteratePrefix(ndb.db, legacyOrphanKeyFormat.Key())
+	if err != nil {
+		return err
+	}
+	defer itr.Close()
+
+	count := 0
+	for ; itr.Valid(); itr.Next() {
+		if err := ndb.batch.Delete(itr.Key()); err != nil {
+			return err
+		}
+
+		// Sleep for a while to avoid blocking the main thread i/o.
+		count++
+		if count > 1000 {
+			count = 0
+			time.Sleep(100 * time.Millisecond)
+		}
+
+	}
+
+	return nil
 }
 
 // DeleteVersionsFrom permanently deletes all tree versions from the given version upwards.

--- a/nodedb.go
+++ b/nodedb.go
@@ -41,10 +41,10 @@ const (
 var (
 	// All new node keys are prefixed with the byte 's'. This ensures no collision is
 	// possible with the legacy nodes, and makes them easier to traverse. They are indexed by the version and the local nonce.
-	nodeKeyFormat = keyformat.NewKeyFormat('s', int64Size+int32Size) // s<version><nonce>
+	nodeKeyFormat = keyformat.NewFastPrefixFormatter('s', int64Size+int32Size) // s<version><nonce>
 
 	// This is only used for the iteration purpose.
-	nodeKeyPrefixFormat = keyformat.NewKeyFormat('s', int64Size) // s<version>
+	nodeKeyPrefixFormat = keyformat.NewFastPrefixFormatter('s', int64Size) // s<version>
 
 	// Key Format for making reads and iterates go through a data-locality preserving db.
 	// The value at an entry will list what version it was written to.
@@ -59,7 +59,7 @@ var (
 	metadataKeyFormat = keyformat.NewKeyFormat('m', 0) // m<keystring>
 
 	// All legacy node keys are prefixed with the byte 'n'.
-	legacyNodeKeyFormat = keyformat.NewKeyFormat('n', hashSize) // n<hash>
+	legacyNodeKeyFormat = keyformat.NewFastPrefixFormatter('n', hashSize) // n<hash>
 
 	// All legacy orphan keys are prefixed with the byte 'o'.
 	legacyOrphanKeyFormat = keyformat.NewKeyFormat('o', int64Size, int64Size, hashSize) // o<last-version><first-version><hash>
@@ -584,7 +584,7 @@ func (ndb *nodeDB) DeleteVersionsFrom(fromVersion int64) error {
 	}
 
 	// Delete the nodes for new format
-	err = ndb.traverseRange(nodeKeyPrefixFormat.Key(fromVersion), nodeKeyPrefixFormat.Key(latest+1), func(k, v []byte) error {
+	err = ndb.traverseRange(nodeKeyPrefixFormat.KeyInt64(fromVersion), nodeKeyPrefixFormat.KeyInt64(latest+1), func(k, v []byte) error {
 		return ndb.batch.Delete(k)
 	})
 
@@ -664,7 +664,7 @@ func (ndb *nodeDB) nodeKey(nk []byte) []byte {
 }
 
 func (ndb *nodeDB) nodeKeyPrefix(version int64) []byte {
-	return nodeKeyPrefixFormat.Key(version)
+	return nodeKeyPrefixFormat.KeyInt64(version)
 }
 
 func (ndb *nodeDB) fastNodeKey(key []byte) []byte {
@@ -760,8 +760,8 @@ func (ndb *nodeDB) getLatestVersion() (int64, error) {
 	}
 
 	itr, err := ndb.db.ReverseIterator(
-		nodeKeyPrefixFormat.Key(int64(1)),
-		nodeKeyPrefixFormat.Key(int64(math.MaxInt64)),
+		nodeKeyPrefixFormat.KeyInt64(int64(1)),
+		nodeKeyPrefixFormat.KeyInt64(int64(math.MaxInt64)),
 	)
 	if err != nil {
 		return 0, err
@@ -1080,7 +1080,7 @@ func isReferenceToRoot(bz []byte) bool {
 func (ndb *nodeDB) traverseNodes(fn func(node *Node) error) error {
 	nodes := []*Node{}
 
-	if err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	if err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		if isReferenceToRoot(value) {
 			return nil
 		}
@@ -1163,7 +1163,7 @@ func (ndb *nodeDB) String() (string, error) {
 
 	index := 0
 
-	err := ndb.traversePrefix(nodeKeyFormat.Key(), func(key, value []byte) error {
+	err := ndb.traversePrefix(nodeKeyFormat.Prefix(), func(key, value []byte) error {
 		fmt.Fprintf(buf, "%s: %x\n", key, value)
 		return nil
 	})

--- a/nodedb.go
+++ b/nodedb.go
@@ -436,14 +436,17 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 		legacyRootKeyFormat.Scan(itr.Key(), &curVersion)
 		rootKeys = append(rootKeys, itr.Key())
 		if prevVersion > 0 {
-			if err := ndb.traverseOrphans(prevVersion, curVersion, func(orphan *Node) error {
-				return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))
-			}); err != nil {
-				return err
-			}
+			go func(prevVersion, curVersion int64) {
+				if err := ndb.traverseOrphans(prevVersion, curVersion, func(orphan *Node) error {
+					return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))
+				}); err != nil {
+					ndb.logger.Error("failed to delete orphans", "err", err)
+				}
+			}(prevVersion, curVersion)
 		}
 		prevVersion = curVersion
 	}
+
 	// Delete the last version for the legacyLastVersion
 	if curVersion > 0 {
 		legacyLatestVersion, err := ndb.getLegacyLatestVersion()
@@ -453,11 +456,13 @@ func (ndb *nodeDB) deleteLegacyVersions() error {
 		if curVersion != legacyLatestVersion {
 			return fmt.Errorf("expected legacyLatestVersion to be %d, got %d", legacyLatestVersion, curVersion)
 		}
-		if err := ndb.traverseOrphans(curVersion, curVersion+1, func(orphan *Node) error {
-			return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))
-		}); err != nil {
-			return err
-		}
+		go func(curVersion int64) {
+			if err := ndb.traverseOrphans(curVersion, curVersion+1, func(orphan *Node) error {
+				return ndb.batch.Delete(ndb.nodeKey(orphan.GetKey()))
+			}); err != nil {
+				ndb.logger.Error("failed to delete orphans", "err", err)
+			}
+		}(curVersion)
 	}
 
 	// Delete all roots of the legacy versions


### PR DESCRIPTION
This feature prevents the multiple hour long waiting period when chains upgrade from previous versions of IAVL to IAVL v1. The time comes from pruning orphan nodes. This synchronously prunes them. This branch has been tested successfully against osmosis mainnet.