### PR TITLE
CV Optimistic Export and Import

### DIFF
--- a/export.go
+++ b/export.go
@@ -78,7 +78,7 @@ func newExporterWithOptions(tree *ImmutableTree, optimistic bool) (*Exporter, er
 
 // export exports nodes
 func (e *Exporter) export(ctx context.Context) {
-	e.tree.root.traversePost(e.tree, true, func(node *Node) bool {
+	_ = e.tree.root.traversePost(e.tree, true, func(node *Node) bool {
 		exportNode := &ExportNode{
 			Key:     node.key,
 			Value:   node.value,

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -160,6 +160,12 @@ func (t *ImmutableTree) Export() (*Exporter, error) {
 	return newExporter(t)
 }
 
+// OptimisiticExport returns an iterator that exports tree nodes as ExportNodes. These nodes can be
+// imported with MutableTree.Import() to recreate an identical tree.
+func (t *ImmutableTree) OptimisticExport() (*Exporter, error) {
+	return newOptimisticExporter(t)
+}
+
 // GetWithIndex returns the index and value of the specified key if it exists, or nil and the next index
 // otherwise. The returned value must not be modified, since it may point to data stored within
 // IAVL.

--- a/import.go
+++ b/import.go
@@ -178,7 +178,9 @@ func (i *Importer) OptimisticAdd(exportNode *ExportNode) error {
 	}
 	i.batchSize++
 
-	i.sendBatchIfFull()
+	if err := i.sendBatchIfFull(); err != nil {
+		return errors.New("failed sending db write batch")
+	}
 
 	return nil
 }
@@ -263,9 +265,8 @@ func (i *Importer) Commit() error {
 		return ErrNoImport
 	}
 
-	if i.optimistic {
-		// All keys should be already imported
-	} else {
+	// Optimistic: All keys should be already imported
+	if !i.optimistic {
 		switch len(i.stack) {
 		case 0:
 			if err := i.batch.Set(i.tree.ndb.nodeKey(GetRootKey(i.version)), []byte{}); err != nil {

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -200,6 +200,12 @@ func (tree *MutableTree) Import(version int64) (*Importer, error) {
 	return newImporter(tree, version)
 }
 
+// OptimisticImport returns an importer for tree nodes previously exported by ImmutableTree.OptimisticExport(),
+// producing an identical IAVL tree. The caller must call Close() on the importer when done.
+func (tree *MutableTree) OptimisticImport(version int64) (*Importer, error) {
+	return newOptimisticImporter(tree, version)
+}
+
 // Iterate iterates over all keys of the tree. The keys and values must not be modified,
 // since they may point to data stored within IAVL. Returns true if stopped by callnack, false otherwise
 func (tree *MutableTree) Iterate(fn func(key []byte, value []byte) bool) (stopped bool, err error) {

--- a/node.go
+++ b/node.go
@@ -707,6 +707,7 @@ func (node *Node) calcBalance(t *ImmutableTree) (int, error) {
 }
 
 // traverse is a wrapper over traverseInRange when we want the whole tree
+// nolint: unparam
 func (node *Node) traverse(t *ImmutableTree, ascending bool, cb func(*Node) bool) bool {
 	return node.traverseInRange(t, nil, nil, ascending, false, false, func(node *Node) bool {
 		return cb(node)

--- a/nodedb.go
+++ b/nodedb.go
@@ -162,6 +162,52 @@ func (ndb *nodeDB) GetNode(nk []byte) (*Node, error) {
 	return node, nil
 }
 
+/*
+// CV GetNodeKeyValueBytes gets a node's key and value bytes from memory or disk.
+// It is used for both formats of nodes: legacy and new.
+// `legacy`: nk is the hash of the node. `new`: <version><nonce>.
+// returns nodeKey []byte, nodeValue
+func (ndb *nodeDB) GetNodeKeyValueBytes(nk []byte) ([]byte, []byte, error) {
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
+
+	if nk == nil {
+		return nil, nil, ErrNodeMissingNodeKey
+	}
+
+	isLegcyNode := len(nk) == hashSize
+	var nodeKey []byte
+	if isLegcyNode {
+		nodeKey = ndb.legacyNodeKey(nk)
+	} else {
+		nodeKey = ndb.nodeKey(nk)
+	}
+
+	valueBytes, err := ndb.db.Get(nodeKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("can't get node %v: %v", nk, err)
+	}
+	if valueBytes == nil {
+		return nil, nil, fmt.Errorf("Value missing for key %v corresponding to nodeKey %x", nk, nodeKey)
+	}
+
+	return nodeKey, valueBytes, nil
+}
+
+// CV SaveNodeKeyValueBytes saves a node to disk with raw byte arrays for key and value.
+func (ndb *nodeDB) SaveNodeKeyValueBytes(keyBytes []byte, valueBytes []byte) error {
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
+
+	if err := ndb.batch.Set(keyBytes, valueBytes); err != nil {
+		return err
+	}
+
+	ndb.logger.Debug("BATCH SAVE", "key", keyBytes, "value", valueBytes)
+	return nil
+}
+*/
+
 func (ndb *nodeDB) GetFastNode(key []byte) (*fastnode.Node, error) {
 	if !ndb.hasUpgradedToFastStorage() {
 		return nil, errors.New("storage version is not fast")


### PR DESCRIPTION
Optimistic Export and Import aims to reduce p2p statesync recovery times.

Validators attempting to recover nodes for cosmos-sdk chains with significant state size may be slashed for downtime prior to recovery.

Although all data is verified during tree build, rebuilding the entire IAVL tree using minimal data incurs high CPU overhead.

Evmos for example takes over 16 hours to rebuild IAVL on a "fast" CPU/DISK machine and can appear to "never finish".  The node must then fast-sync 16 hours of missed blocks which can take an additional 4-5 hours.  Slashing for downtime is within 30 hours meaning a validator must succeed on the first try or be slashed.

Since statesync appears to "hang", validators download a 244GB file from Polkachu to restore data directories.  This is possible because Polkachu is a trusted party.  Validators do not appear to validate the correctness of the IAVL tree so this method is less trusted but necessary. The problem is when Polkachu only makes 1 snapshot every 24 hours.  A validator may need to fast-sync 23 hours of lost block, wait for the next Polkachu snapshot, or try another random less known snapshot.

Optimistic statesync enables faster database import at the restoring node by directly inserting the final key/value pairs into the database.  As long as validators statesync from a trusted node, this can be a good alternative to downloading data directory zip files.

Cosmos-sdk should broadcast a different snapshot format so that nodes can select optimistic statesync node sources.

There are some code locations below where there may be more efficient methods to obtain the raw key/value storage than recalculation.

Comments welcome.