### PR TITLE
fix: pass initial version at immutable tree creation

### DIFF
--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -56,7 +56,7 @@ func NewMutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, lg lo
 	}
 
 	ndb := newNodeDB(db, cacheSize, opts, lg)
-	head := &ImmutableTree{ndb: ndb, skipFastStorageUpgrade: skipFastStorageUpgrade, version: int64(opts.InitialVersion)}
+	head := &ImmutableTree{ndb: ndb, skipFastStorageUpgrade: skipFastStorageUpgrade}
 
 	return &MutableTree{
 		logger:                   lg,
@@ -460,6 +460,8 @@ func (tree *MutableTree) LoadVersion(targetVersion int64) (int64, error) {
 
 	if firstVersion == 0 {
 		if targetVersion <= 0 {
+			tree.version = int64(tree.ndb.opts.InitialVersion)
+
 			if !tree.skipFastStorageUpgrade {
 				tree.mtx.Lock()
 				defer tree.mtx.Unlock()

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -56,7 +56,7 @@ func NewMutableTree(db dbm.DB, cacheSize int, skipFastStorageUpgrade bool, lg lo
 	}
 
 	ndb := newNodeDB(db, cacheSize, opts, lg)
-	head := &ImmutableTree{ndb: ndb, skipFastStorageUpgrade: skipFastStorageUpgrade}
+	head := &ImmutableTree{ndb: ndb, skipFastStorageUpgrade: skipFastStorageUpgrade, version: int64(opts.InitialVersion)}
 
 	return &MutableTree{
 		logger:                   lg,


### PR DESCRIPTION
In previous iavl, the version is not affecting to working hash. but in current iavl, the version is a part of working hash, so the `InitialVersion` should be used when you make working hash at newly added moules. 

https://github.com/cosmos/iavl/blob/af7ae13f47a477f11c18a4856d4a0c4e4a344e45/node.go#L435

The problem is happening when you adding an new module [`packetforward`](https://github.com/cosmos/ibc-apps/tree/main/middleware/packet-forward-middleware), you can easily reproduce the consensus breaking with software upgrade proposal. You should run more than two nodes and after upgrade restart validator node and see other nodes.

We deeply debugged it and found the working hash for the stores, which are added via upgrade, are same whatever the height you did upgrade (` [164 128 39 101 194 146 82 214 50 145 131 89 83 171 212 207 142 176 239 6 10 8 254 1 95 237 121 132 93 24 213 34]` for `packetforward`). but it should be differ in current iavl because it is using version to make working hash. and also found it is using `tree.version`, which is 0, when a new module firstly added by upgrade module. This wrong store hash is kept only in runtime. When you restart the node, it makes different `WorkingHash` and then consensus broken. 

