### PR TITLE
perf: fix accidentally undone Go map[string(byteslice)] lookup optimization

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -61,8 +61,8 @@ func New(maxElementCount int) Cache {
 }
 
 func (c *lruCache) Add(node Node) Node {
-	key := string(node.GetKey())
-	if e, exists := c.dict[key]; exists {
+	key := node.GetKey()
+	if e, exists := c.dict[string(key)]; exists {
 		c.ll.MoveToFront(e)
 		old := e.Value
 		e.Value = node
@@ -70,7 +70,7 @@ func (c *lruCache) Add(node Node) Node {
 	}
 
 	elem := c.ll.PushFront(node)
-	c.dict[key] = elem
+	c.dict[string(key)] = elem
 
 	if c.ll.Len() > c.maxElementCount {
 		oldest := c.ll.Back()
@@ -97,9 +97,8 @@ func (c *lruCache) Len() int {
 }
 
 func (c *lruCache) Remove(key []byte) Node {
-	keyS := string(key)
-	if elem, exists := c.dict[keyS]; exists {
-		return c.removeWithKey(elem, keyS)
+	if elem, exists := c.dict[string(key)]; exists {
+		return c.removeWithKey(elem, string(key))
 	}
 	return nil
 }


### PR DESCRIPTION
This change brings back an optimization that go innocently removed while trying to reduce the number of invocations to node.GetKey() in PR #890.

The Go compiler considers the special case of lookups per:

    value, ok := map[string(byteslice)]
or
    value := map[string(byteslice)]

and performs a zero byteslice->string conversion because it knows that there is no storing in the map hence a read-only usage of the byteslice's memory.