### PR TITLE
perf(encoding): speed up EncodeVarint with io.ByteWriter+hand rolled varintEncode

### DIFF
--- a/internal/encoding/bench_test.go
+++ b/internal/encoding/bench_test.go
@@ -1,0 +1,59 @@
+package encoding
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"testing"
+)
+
+var encValues = []int64{
+	-1, -100, -1 << 32,
+	0, 1, 100, 1 << 32,
+	-1 << 52, 1 << 52, 17,
+	19, 28, 37, 388888888,
+	-99999999999, 99999999999,
+	math.MaxInt64, math.MinInt64,
+}
+
+// This tests that the results from directly invoking binary.PutVarint match
+// exactly those that we get from invoking EncodeVarint and its internals.
+func TestEncodeVarintParity(t *testing.T) {
+	buf := new(bytes.Buffer)
+	var board [binary.MaxVarintLen64]byte
+
+	for _, val := range encValues {
+		val := val
+		name := fmt.Sprintf("%d", val)
+
+		buf.Reset()
+		t.Run(name, func(t *testing.T) {
+			if err := EncodeVarint(buf, val); err != nil {
+				t.Fatal(err)
+			}
+
+			n := binary.PutVarint(board[:], val)
+			got := buf.Bytes()
+			want := board[:n]
+			if !bytes.Equal(got, want) {
+				t.Fatalf("Result mismatch\n\tGot:  %d\n\tWant: %d", got, want)
+			}
+		})
+	}
+}
+
+func BenchmarkEncodeVarint(b *testing.B) {
+	buf := new(bytes.Buffer)
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, val := range encValues {
+			if err := EncodeVarint(buf, val); err != nil {
+				b.Fatal(err)
+			}
+			buf.Reset()
+		}
+	}
+}


### PR DESCRIPTION
This change speeds up EncodeVarint by testing if the input writer implements io.ByteWriter and if so, goes to use our hand-rolled varint encoder, instead of using the awkward standard libary encoding/binary.PutVarint that requires a byteslice, which we also retrofitted using a bytearray pool.
While here, added parity tests to ensure that we get the exact same results as with the Go standard library's encoding/binary package with caution from https://cyber.orijtech.com/advisory/varint-decode-limitless and also added benchmarks whose results reflect the change in just the benchmark initially

```shell
$ benchstat before.txt after.txt
name            old time/op    new time/op    delta
EncodeVarint-8     360ns ± 3%     245ns ± 3%  -31.80%  (p=0.000 n=10+10)

name            old alloc/op   new alloc/op   delta
EncodeVarint-8     0.00B          0.00B          ~     (all equal)

name            old allocs/op  new allocs/op  delta
EncodeVarint-8      0.00           0.00          ~     (all equal)
```

Fixes #891