### PR TITLE
Prevent wasted time on Commit

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -32,6 +32,9 @@ type Cache interface {
 
 	// Len returns the cache length.
 	Len() int
+
+	// Capacity returns the maximum number of nodes the cache can hold.
+	Capacity() int
 }
 
 // lruCache is an LRU cache implementation.
@@ -94,6 +97,10 @@ func (c *lruCache) Has(key []byte) bool {
 
 func (c *lruCache) Len() int {
 	return c.ll.Len()
+}
+
+func (c *lruCache) Capacity() int {
+	return c.maxElementCount
 }
 
 func (c *lruCache) Remove(key []byte) Node {

--- a/nodedb.go
+++ b/nodedb.go
@@ -204,7 +204,7 @@ func (ndb *nodeDB) GetFastNode(key []byte) (*fastnode.Node, error) {
 }
 
 // SaveNode saves a node to disk.
-func (ndb *nodeDB) SaveNode(node *Node) error {
+func (ndb *nodeDB) SaveNode(node *Node, useLruCache bool) error {
 	ndb.mtx.Lock()
 	defer ndb.mtx.Unlock()
 
@@ -225,7 +225,9 @@ func (ndb *nodeDB) SaveNode(node *Node) error {
 	}
 
 	ndb.logger.Debug("BATCH SAVE", "node", node)
-	ndb.nodeCache.Add(node)
+	if useLruCache {
+		ndb.nodeCache.Add(node)
+	}
 	return nil
 }
 
@@ -386,7 +388,7 @@ func (ndb *nodeDB) deleteVersion(version int64) error {
 		}
 		// instead, the root should be reformatted to (version, 0)
 		root.nodeKey.nonce = 0
-		if err := ndb.SaveNode(root); err != nil {
+		if err := ndb.SaveNode(root, true); err != nil {
 			return err
 		}
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -1775,7 +1775,7 @@ func TestNodeCacheStatisic(t *testing.T) {
 		expectCacheMissCnt     int
 	}{
 		"with_cache": {
-			cacheSize:              numKeyVals,
+			cacheSize:              2 * numKeyVals, // has to cover all inner nodes
 			expectFastCacheHitCnt:  numKeyVals,
 			expectFastCacheMissCnt: 0,
 			expectCacheHitCnt:      1,


### PR DESCRIPTION
This PR optimizes LRU cache usage on large commits.

If the amount of internal nodes added exceeds cache capacity, only add the first $CAPACITY nodes to the LRU cache. Anything else we add thrashes something we just added, hence is a wasted overhead.