### PR TITLE
fix: working hash with initial version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v1.0.4 May 7, 2024
+
+### Bug Fixes
+
+- [#943](https://github.com/cosmos/iavl/pull/943) Fix the `WorkingHash` with the `InitialVersion` option.
+
 ## v1.0.3 April 8, 2024
 
 ### Bug Fixes

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -140,7 +140,7 @@ func (tree *MutableTree) Hash() []byte {
 
 // WorkingHash returns the hash of the current working tree.
 func (tree *MutableTree) WorkingHash() []byte {
-	return tree.ImmutableTree.Hash()
+	return tree.root.hashWithCount(tree.WorkingVersion())
 }
 
 func (tree *MutableTree) WorkingVersion() int64 {

--- a/tree_test.go
+++ b/tree_test.go
@@ -1920,3 +1920,37 @@ func TestReferenceRoot(t *testing.T) {
 	_, err = tree.Set([]byte("key1"), []byte("value2"))
 	require.NoError(t, err)
 }
+
+func TestWorkingHashWithInitialVersion(t *testing.T) {
+	db, err := dbm.NewDB("test", "memdb", "")
+	require.NoError(t, err)
+	defer db.Close()
+
+	initialVersion := int64(100)
+	tree := NewMutableTree(db, 0, false, log.NewNopLogger())
+	tree.SetInitialVersion(uint64(initialVersion))
+
+	v := tree.WorkingVersion()
+	require.Equal(t, initialVersion, v)
+
+	_, err = tree.Set([]byte("key1"), []byte("value1"))
+	require.NoError(t, err)
+
+	workingHash := tree.WorkingHash()
+	commitHash, _, err := tree.SaveVersion()
+	require.NoError(t, err)
+	require.Equal(t, commitHash, workingHash)
+
+	db, err = dbm.NewDB("test", "memdb", "")
+	require.NoError(t, err)
+
+	// without WorkingHash
+	tree = NewMutableTree(db, 0, false, log.NewNopLogger(), InitialVersionOption(uint64(initialVersion)))
+
+	_, err = tree.Set([]byte("key1"), []byte("value1"))
+	require.NoError(t, err)
+
+	commitHash1, _, err := tree.SaveVersion()
+	require.NoError(t, err)
+	require.Equal(t, commitHash1, commitHash)
+}


### PR DESCRIPTION
## Context

`InitialVersion` is not reflected in the `WorkingHash` calculation, only reflected in the `SaveVersion`. This will lead to the `AppHash` mismatch while upgrading, since the the hash of the root is already calculated in the `WorkingHash` and won't re-calculated in the `SaveVersion` which is wrong.