### PR TITLE
fix: make install error #979

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ all: lint test install
 
 install:
 ifeq ($(COLORS_ON),)
-	go install ./cmd/iaviewer
+	cd cmd && go mod tidy && go install ./iaviewer
 else
-	go install $(CMDFLAGS) ./cmd/iaviewer
+	cd cmd && go mod tidy && go install $(CMDFLAGS) ./iaviewer
 endif
 .PHONY: install
 

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos/iavl/cmd
 go 1.21
 
 require (
-	cosmossdk.io/core v0.12.1-0.20240811203112-84a9978c9c5f
+	cosmossdk.io/core v0.12.1-0.20240813134434-072a29c838a5
 	cosmossdk.io/log v1.3.1
 	github.com/cosmos/iavl v1.2.0
 )

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1,5 +1,5 @@
-cosmossdk.io/core v0.12.1-0.20240811203112-84a9978c9c5f h1:lfTuR1+0fmnjC7C45dPOGYp7bP9M5zvU40SPpYD/dTE=
-cosmossdk.io/core v0.12.1-0.20240811203112-84a9978c9c5f/go.mod h1:cG0MhpD1ZvVU7vnTlJ5OcafpwxB7yVjgtMtkduDOnSU=
+cosmossdk.io/core v0.12.1-0.20240813134434-072a29c838a5 h1:aIfrfJUronk2qHPH4N7M5nGzijdSWkRwHHqqPGnQBrk=
+cosmossdk.io/core v0.12.1-0.20240813134434-072a29c838a5/go.mod h1:B8JQN1vmGCPSVFlmRb/22n1T736P4C2qfEsrSKDX1iM=
 cosmossdk.io/log v1.3.1 h1:UZx8nWIkfbbNEWusZqzAx3ZGvu54TZacWib3EzUYmGI=
 cosmossdk.io/log v1.3.1/go.mod h1:2/dIomt8mKdk6vl3OWJcPk2be3pGOS8OQaLUM/3/tCM=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
@@ -25,8 +25,8 @@ github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrU
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v1.1.2 h1:xf4v41cLI2Z6FxbKm+8Bu+m8ifhj15JuZ9sa0jZCMUU=


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Improved installation process by automatically running go mod tidy in the cmd directory before installation.

- **Bug Fixes**
	- Resolved potential issues with make install failing due to missing dependencies in the cmd module.
	- Adjusted the Makefile to ensure the correct directory context for Go commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->