### PR TITLE
fix: unprotected read data race

### DIFF
--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -190,10 +190,15 @@ func (t *ImmutableTree) Get(key []byte) ([]byte, error) {
 		}
 
 		if fastNode == nil {
+			latestVersion, err := t.ndb.getLatestVersion()
+			if err != nil {
+				return nil, err
+			}
+
 			// If the tree is of the latest version and fast node is not in the tree
 			// then the regular node is not in the tree either because fast node
 			// represents live state.
-			if t.version == t.ndb.latestVersion {
+			if t.version == latestVersion {
 				return nil, nil
 			}
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -190,15 +190,10 @@ func (t *ImmutableTree) Get(key []byte) ([]byte, error) {
 		}
 
 		if fastNode == nil {
-			latestVersion, err := t.ndb.getLatestVersion()
-			if err != nil {
-				return nil, err
-			}
-
 			// If the tree is of the latest version and fast node is not in the tree
 			// then the regular node is not in the tree either because fast node
 			// represents live state.
-			if t.version == latestVersion {
+			if t.version == t.ndb.safeGetLatestVersion() {
 				return nil, nil
 			}
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -797,6 +797,15 @@ func (ndb *nodeDB) resetLegacyLatestVersion(version int64) {
 	ndb.legacyLatestVersion = version
 }
 
+// safeGetLatestVersion returns the value of ndb.latestVersion directly
+// without additional logic performed by getLatestVersion.
+func (ndb *nodeDB) safeGetLatestVersion() int64 {
+	ndb.mtx.Lock()
+	defer ndb.mtx.Unlock()
+
+	return ndb.latestVersion
+}
+
 func (ndb *nodeDB) getLatestVersion() (int64, error) {
 	ndb.mtx.Lock()
 	latestVersion := ndb.latestVersion


### PR DESCRIPTION
This fixes a data race in immutable tree that accesses `nodeDB.latestVersion` without acquiring the lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced version checking in the Get method to ensure it accurately reflects the latest data state.
	- Introduced a new method for efficient retrieval of the latest version, improving performance in frequent access scenarios.
	- Improved error handling for database interactions during version retrieval.

- **Bug Fixes**
	- Resolved issues related to version comparison logic, ensuring more reliable results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->