### PR TITLE
feat: allow saving version 0

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -838,7 +838,7 @@ func (ndb *nodeDB) getLatestVersion() (int64, error) {
 		return latestVersion, nil
 	}
 
-	return 0, nil
+	return -1, nil
 }
 
 func (ndb *nodeDB) resetLatestVersion(version int64) {


### PR DESCRIPTION
This patch makes `SetInitialVersion(0)` calls valid, which previously would error during `SaveVersion`.  This is particularly useful for the server/v2 which processes and saves a Genesis block at version `initialHeight -1`, which is 0 is the default case.