### PR TITLE
bug: root node get pruned when it's still referenced

### DIFF
--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1494,3 +1494,27 @@ func TestMutableTree_InitialVersionZero(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(0), version)
 }
+
+func TestReferenceRootPruning(t *testing.T) {
+	memDB := dbm.NewMemDB()
+	tree := NewMutableTree(memDB, 0, true, NewNopLogger())
+
+	_, err := tree.Set([]byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	_, err = tree.Set([]byte("foo1"), []byte("bar"))
+	require.NoError(t, err)
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	err = tree.DeleteVersionsTo(1)
+	require.NoError(t, err)
+
+	_, err = tree.Set([]byte("foo"), []byte("bar*"))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Wrote a unit test to reproduce.

thanks @mmsqe 

the problem is [here](https://github.com/cosmos/iavl/blob/master/nodedb.go#L456), we can't simply delete the old root node because it might be referenced by other versions down the road, but I guess we also can't leave it there, because it might create a gap in the versions, which violates the assumption in the design, right? @cool-develope  