### PR TITLE
fix: Add Extra Check for Reformatted Root Node in GetNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- [#1007](https://github.com/cosmos/iavl/pull/1007) Add the extra check for the reformatted root node in `GetNode`
+
 ### Improvements
 
 - [#952](https://github.com/cosmos/iavl/pull/952) Add `DeleteVersionsFrom(int64)` API.

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -1479,3 +1479,27 @@ func TestMutableTreeClose(t *testing.T) {
 
 	require.NoError(t, tree.Close())
 }
+
+func TestReferenceRootPruning(t *testing.T) {
+	memDB := dbm.NewMemDB()
+	tree := NewMutableTree(memDB, 0, true, NewNopLogger())
+
+	_, err := tree.Set([]byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	_, err = tree.Set([]byte("foo1"), []byte("bar"))
+	require.NoError(t, err)
+	_, _, err = tree.SaveVersion()
+	require.NoError(t, err)
+
+	err = tree.DeleteVersionsTo(1)
+	require.NoError(t, err)
+
+	_, err = tree.Set([]byte("foo"), []byte("bar*"))
+	require.NoError(t, err)
+}

--- a/nodedb.go
+++ b/nodedb.go
@@ -159,6 +159,20 @@ func (ndb *nodeDB) GetNode(nk []byte) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("can't get node %v: %v", nk, err)
 	}
+	if buf == nil && !isLegcyNode {
+		// if the node is reformatted by pruning, check against (version, 0)
+		nKey := GetNodeKey(nk)
+		if nKey.nonce == 1 {
+			nodeKey = ndb.nodeKey((&NodeKey{
+				version: nKey.version,
+				nonce:   0,
+			}).GetKey())
+			buf, err = ndb.db.Get(nodeKey)
+			if err != nil {
+				return nil, fmt.Errorf("can't get the reformatted node %v: %v", nk, err)
+			}
+		}
+	}
 	if buf == nil {
 		return nil, fmt.Errorf("Value missing for key %v corresponding to nodeKey %x", nk, nodeKey)
 	}


### PR DESCRIPTION
## Problem Description

When the root node is reformatted due to pruning, its nodeKey changes from (version, 1) to (version, 0). As a result:

	1.	This version becomes invisible during a root search.
	2.	If a node in the next version references the reformatted node, it becomes inaccessible.

## Proposed Solution

Add an extra check in the GetNode function to handle reformatted root nodes. This ensures that:

	•	Reformatted nodes with nodeKey (version, 0) remain accessible.
	•	References to these nodes from subsequent versions are correctly resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new test to validate the behavior of the `MutableTree` after version deletions.
	- Added new APIs: `DeleteVersionsFrom(int64)` and `GetLatestVersion`.

- **Bug Fixes**
	- Enhanced the `GetNode` method to improve retrieval logic for nodes, ensuring better handling of cases with `nil` buffers and legacy nodes.

- **Documentation**
	- Updated the changelog to reflect recent improvements and fixes, including a new section for bug fixes and detailed descriptions of changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->