### PR TITLE
cache first version for legacy versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - [#965](https://github.com/cosmos/iavl/pull/965) Use expected interface for expected IAVL `Logger`.
 - [#970](https://github.com/cosmos/iavl/pull/970) Close the pruning process when the nodeDB is closed.
 - [#980](https://github.com/cosmos/iavl/pull/980) Use the `sdk/core/store.KVStoreWithBatch` interface instead of `iavl/db.DB` interface
-- [#]() Cache first version for legacy versions, fix performance regression after upgrade.
+- [#1018](https://github.com/cosmos/iavl/pull/1018) Cache first version for legacy versions, fix performance regression after upgrade.
 
 ## v1.2.0 May 13, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [#965](https://github.com/cosmos/iavl/pull/965) Use expected interface for expected IAVL `Logger`.
 - [#970](https://github.com/cosmos/iavl/pull/970) Close the pruning process when the nodeDB is closed.
 - [#980](https://github.com/cosmos/iavl/pull/980) Use the `sdk/core/store.KVStoreWithBatch` interface instead of `iavl/db.DB` interface
+- [#]() Cache first version for legacy versions, fix performance regression after upgrade.
 
 ## v1.2.0 May 13, 2024
 

--- a/nodedb.go
+++ b/nodedb.go
@@ -738,6 +738,7 @@ func (ndb *nodeDB) getFirstVersion() (int64, error) {
 	if itr.Valid() {
 		var version int64
 		legacyRootKeyFormat.Scan(itr.Key(), &version)
+		ndb.resetFirstVersion(version)
 		return version, nil
 	}
 	// Find the first version


### PR DESCRIPTION
fix performance regression after upgrade.

## Context

We see higher cpu usage in rpc nodes when serving similar traffic of queries, we dump a golang trace and see following stacktrace appears frequently, we suspect this to be the issue.
The first version in ndb seems should be cached, but it's not in legacy version case, which cause an extra seek call to underlying db, and the extra call happens for each store and for each query request.

```
github.com/linxGnu/grocksdb._Cfunc_rocksdb_iter_seek:3593
--
github.com/linxGnu/grocksdb.(*Iterator).Seek.func1:108
github.com/linxGnu/grocksdb.(*Iterator).Seek:108
github.com/cosmos/cosmos-db.newRocksDBIterator:40
github.com/cosmos/cosmos-db.(*RocksDB).Iterator:215
github.com/cosmos/cosmos-db.(*PrefixDB).Iterator:112
cosmossdk.io/store/wrapper.(*DBWrapper).Iterator:29
github.com/cosmos/iavl.(*nodeDB).getPrefixIterator:1002
github.com/cosmos/iavl.(*nodeDB).getFirstVersion:735
github.com/cosmos/iavl.(*MutableTree).VersionExists:88
cosmossdk.io/store/iavl.(*Store).VersionExists:176
cosmossdk.io/store/iavl.(*Store).GetImmutable:109
cosmossdk.io/store/rootmulti.(*Store).CacheMultiStoreWithVersion:612
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).CreateQueryContext:1270
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func1:49
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2.ChainUnaryServer.2.1:48
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1:33
github.com/cosmos/cosmos-sdk/baseapp.(*BaseApp).RegisterGRPCServer.func2.ChainUnaryServer.2:53
```

We've verified this fix reduce the cpu usage on the nodes quite effective.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new APIs: `DeleteVersionsFrom(int64)` and `GetLatestVersion`.
  
- **Bug Fixes**
	- Added extra check for reformatted root node in `GetNode`.
	- Fixed performance regression by caching the first version for legacy versions.

- **Improvements**
	- Enhanced error handling for node retrieval methods.
	- Improved version management within the database. 

- **Documentation**
	- Updated changelog with new entries for bug fixes and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->