### PR TITLE
perf: remove duplicated rootkey fetch inpruning (9% pruning speedup on osmosis)

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -416,10 +416,32 @@ func (ndb *nodeDB) saveNodeFromPruning(node *Node) error {
 	return ndb.batch.Set(ndb.nodeKey(node.GetKey()), buf.Bytes())
 }
 
+type rootkeyCache struct {
+	version int64
+	rootKey []byte
+}
+
+func (rkc *rootkeyCache) getRootKey(ndb *nodeDB, version int64) ([]byte, error) {
+	if rkc.version == version {
+		return rkc.rootKey, nil
+	}
+	rootKey, err := ndb.GetRoot(version)
+	if err != nil {
+		return nil, err
+	}
+	rkc.setRootKey(version, rootKey)
+	return rootKey, nil
+}
+
+func (rkc *rootkeyCache) setRootKey(version int64, rootKey []byte) {
+	rkc.version = version
+	rkc.rootKey = rootKey
+}
+
 // deleteVersion deletes a tree version from disk.
 // deletes orphans
-func (ndb *nodeDB) deleteVersion(version int64) error {
-	rootKey, err := ndb.GetRoot(version)
+func (ndb *nodeDB) deleteVersion(version int64, cache *rootkeyCache) error {
+	rootKey, err := cache.getRootKey(ndb, version)
 	if err != nil {
 		return err
 	}
@@ -457,7 +479,7 @@ func (ndb *nodeDB) deleteVersion(version int64) error {
 	}
 
 	// check if the version is referred by the next version
-	nextRootKey, err := ndb.GetRoot(version + 1)
+	nextRootKey, err := cache.getRootKey(ndb, version+1)
 	if err != nil {
 		return err
 	}
@@ -684,8 +706,9 @@ func (ndb *nodeDB) deleteVersionsTo(toVersion int64) error {
 		ndb.resetLegacyLatestVersion(-1)
 	}
 
+	rootkeyCache := &rootkeyCache{}
 	for version := first; version <= toVersion; version++ {
-		if err := ndb.deleteVersion(version); err != nil {
+		if err := ndb.deleteVersion(version, rootkeyCache); err != nil {
 			return err
 		}
 		ndb.resetFirstVersion(version + 1)


### PR DESCRIPTION
Currently delete version duplicatedly fetches rootkeys. This rootkey fetch does not go through the normal caching logic (as the rootkey fetch call does a direct call to the underlying database. Its not routed through the standard GetNode cache wrappers)


I did a 2 hour long block sync on osmosis, which got through 66000 blocks. 
We should cache this root setting logic. Right now root key fetching is ~37% of the block pruning time during my latest sync. And block pruning is 40% of the overall sync time. 

This PR does a quick cache to reduce from 4 calls to 3 calls. (TraverseOrphans has 2 calls as well) Ideally we can setup a second cache later on to ensure none of these DB calls get repeated, but for now wanted to keep it simple/uncontroversial with this PR, getting an 9% speedup to pruning's sync time component. (and ~4% to overall block sync)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a caching mechanism for root keys to enhance retrieval efficiency.
	- Added methods for managing root key caching, including fetching and updating keys.

- **Bug Fixes**
	- Optimized version deletion process by reducing database access through caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->