### PR TITLE
fix: error handling in Iterator.Next() method

### DIFF
--- a/iterator.go
+++ b/iterator.go
@@ -228,10 +228,13 @@ func (iter *Iterator) Next() {
 	}
 
 	node, err := iter.t.next()
-	// TODO: double-check if this error is correctly handled.
+	// Properly handle the error by storing it in iter.err
 	if node == nil || err != nil {
 		iter.t = nil
 		iter.valid = false
+		if err != nil {
+			iter.err = err
+		}
 		return
 	}
 


### PR DESCRIPTION
This PR fixes the error handling in the Iterator.Next() method by properly storing the error in the iter.err field, similar to how it's done in FastIterator.

The TODO comment "double-check if this error is correctly handled" has been addressed by adding code to store the error in the iter.err field when an error occurs during the traversal.next() call.

This ensures that the error can be properly retrieved later via the Error() method, maintaining consistency with other iterator implementations in the codebase.