### PR TITLE
Update cosmossdk.io/core dependency to v1.0.0

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.21
 toolchain go1.23.4
 
 require (
-	cosmossdk.io/core v1.0.0-alpha.6
+	cosmossdk.io/core v1.0.0
 	cosmossdk.io/log v1.3.1
 	github.com/cosmos/iavl v1.2.0
 )


### PR DESCRIPTION
This PR updates the cosmossdk.io/core dependency from v1.0.0-alpha.6 to v1.0.0 in cmd/go.mod.

The change removes the alpha version tag and updates to the stable release version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded a core dependency from an early experimental version to its latest stable release, reinforcing overall system reliability and performance. This routine update aligns with the most dependable release standards, ensuring that end-users enjoy a more stable and consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->