### PR TITLE
fix: get latest version in store after legacy pruning fails

### DIFF
--- a/nodedb.go
+++ b/nodedb.go
@@ -724,7 +724,15 @@ func (ndb *nodeDB) deleteVersionsTo(toVersion int64) error {
 		if err := ndb.deleteLegacyVersions(legacyLatestVersion); err != nil {
 			ndb.logger.Error("Error deleting legacy versions", "err", err)
 		}
-		first = legacyLatestVersion + 1
+		// NOTE: When pruning is broken for legacy versions we need to find the
+		// latest non legacy version in the store
+		// TODO: Make sure legacy pruning works as expected and does not fail
+		firstNonLegacyVersion, err := ndb.getFirstNonLegacyVersion()
+		if err != nil {
+			return err
+		}
+		first = firstNonLegacyVersion
+
 		// reset the legacy latest version forcibly to avoid multiple calls
 		ndb.resetLegacyLatestVersion(-1)
 	}
@@ -764,6 +772,35 @@ func (ndb *nodeDB) legacyNodeKey(nk []byte) []byte {
 
 func (ndb *nodeDB) legacyRootKey(version int64) []byte {
 	return legacyRootKeyFormat.Key(version)
+}
+
+// getFirstNonLegacyVersion binary searches the store for the first non-legacy version
+func (ndb *nodeDB) getFirstNonLegacyVersion() (int64, error) {
+	ndb.mtx.Lock()
+	firstVersion := ndb.firstVersion
+	ndb.mtx.Unlock()
+
+	// Find the first version
+	_, latestVersion, err := ndb.getLatestVersion()
+	if err != nil {
+		return 0, err
+	}
+	for firstVersion < latestVersion {
+		version := (latestVersion + firstVersion) >> 1
+		has, err := ndb.hasVersion(version)
+		if err != nil {
+			return 0, err
+		}
+		if has {
+			latestVersion = version
+		} else {
+			firstVersion = version + 1
+		}
+	}
+
+	ndb.resetFirstVersion(latestVersion)
+
+	return latestVersion, nil
 }
 
 func (ndb *nodeDB) getFirstVersion() (int64, error) {


### PR DESCRIPTION
### Description

Currently if legacy pruning fails it sets the `firstVersion` to `latestLegacyVersion + 1`

That works under the assumption that if legacy pruning fails that the non-legacy node is the first version is available in the store, this is not the case, and the code will then linearly iterate until it finds the next version, which could be a long wait.

### Context
please read https://github.com/cosmos/iavl/pull/1063 for context on this issue

### What this function does

- A binary search to find the latest non-legacy version in the store
- This is a monkey patch and should only run only once when a node start pruning then never again, then the cached first version should be kept per node pruning session 

### What should actually happen

- Pruning should succeed for legacy node
- We should still search for the latest none-legacy node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the process for cleaning up outdated versions, ensuring the system retains only valid data for improved reliability.

- **Tests**
  - Added comprehensive tests that validate the improved version cleanup under various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->