### PR TITLE
docs: fix typos and grammar in documentation and comments

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -23,7 +23,7 @@ The rest of this document is the planned or completed actions for the above-list
 ## Cleanup
 
 Done in branch `cleanup_deps`:
-  * Fixed up dependeny management (tmlibs/db etc in glide/vendor)
+  * Fixed up dependency management (tmlibs/db etc in glide/vendor)
   * Updated Makefile (test, bench, get_deps)
   * Fixed broken code - `looper.go` and one benchmark didn't run
 

--- a/immutable_tree.go
+++ b/immutable_tree.go
@@ -52,7 +52,7 @@ func (t *ImmutableTree) String() string {
 	return "Tree{" + strings.Join(leaves, ", ") + "}"
 }
 
-// RenderShape provides a nested tree shape, ident is prepended in each level
+// RenderShape provides a nested tree shape, indent is prepended in each level
 // Returns an array of strings, one per line, to join with "\n" or display otherwise
 func (t *ImmutableTree) RenderShape(indent string, encoder NodeEncoder) ([]string, error) {
 	if encoder == nil {
@@ -63,7 +63,7 @@ func (t *ImmutableTree) RenderShape(indent string, encoder NodeEncoder) ([]strin
 
 // NodeEncoder will take an id (hash, or key for leaf nodes), the depth of the node,
 // and whether or not this is a leaf node.
-// It returns the string we wish to print, for iaviwer
+// It returns the string we wish to print, for iavlviewer
 type NodeEncoder func(id []byte, depth int, isLeaf bool) string
 
 // defaultNodeEncoder can encode any node unless the client overrides it
@@ -209,7 +209,7 @@ func (t *ImmutableTree) Get(key []byte) ([]byte, error) {
 
 	// otherwise skipFastStorageUpgrade is true or
 	// the cached node was updated later than the current tree. In this case,
-	// we need to use the regular stategy for reading from the current tree to avoid staleness.
+	// we need to use the regular strategy for reading from the current tree to avoid staleness.
 	_, result, err := t.root.get(t, key)
 	return result, err
 }
@@ -326,7 +326,7 @@ func (t *ImmutableTree) nodeSize() int {
 	return int(t.root.size*2 - 1)
 }
 
-// TraverseStateChanges iterate the range of versions, compare each version to it's predecessor to extract the state changes of it.
+// TraverseStateChanges iterate the range of versions, compare each version to its predecessor to extract the state changes of it.
 // endVersion is exclusive.
 func (t *ImmutableTree) TraverseStateChanges(startVersion, endVersion int64, fn func(version int64, changeSet *ChangeSet) error) error {
 	return t.ndb.traverseStateChanges(startVersion, endVersion, fn)

--- a/iterator.go
+++ b/iterator.go
@@ -68,12 +68,12 @@ func (nodes *delayedNodes) length() int {
 // next traversal to proceed, or simply discard the `traversal` struct to stop iteration.
 //
 // At the each step of `next`, the `delayedNodes` can have one of the three states:
-// 1. It has length of 0, meaning that their is no more traversable nodes.
+// 1. It has length of 0, meaning that there is no more traversable nodes.
 // 2. It has length of 1, meaning that the traverse is being started from the initial node.
 // 3. It has length of 2>=, meaning that there are delayed nodes to be traversed.
 //
 // When the `delayedNodes` are not empty, `next` retrieves the first `delayedNode` and initially check:
-// 1. If it is not an delayed node (node.delayed == false) it immediately returns it.
+// 1. If it is not a delayed node (node.delayed == false) it immediately returns it.
 //
 // A. If the `node` is a branch node:
 //  1. If the traversal is postorder, then append the current node to the t.delayedNodes,
@@ -164,7 +164,7 @@ func (t *traversal) next() (*Node, error) {
 		return node, nil
 	}
 
-	// Keep traversing and expanding the remaning delayed nodes. A-4.
+	// Keep traversing and expanding the remaining delayed nodes. A-4.
 	return t.next()
 }
 
@@ -255,7 +255,7 @@ func (iter *Iterator) Error() error {
 	return iter.err
 }
 
-// IsFast returnts true if iterator uses fast strategy
+// IsFast returns true if iterator uses fast strategy
 func (iter *Iterator) IsFast() bool {
 	return false
 }


### PR DESCRIPTION
**Fixed the following typos and grammar issues:**
- `dependeny` -> `dependency` in PERFORMANCE.md
- `ident` -> `indent` in RenderShape comment
- `iaviwer` -> `iavlviewer` in NodeEncoder comment
- `stategy` -> `strategy` in immutable_tree.go comment
- `it's` -> `its` in TraverseStateChanges comment
- `their` -> `there` in iterator comment
- `an` -> `a` in delayed node comment
- `remaning` -> `remaining` in traversal comment
- `returnts` -> `returns` in IsFast comment

These changes improve code documentation readability and fix grammatical errors in comments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

This update introduces minor textual corrections that enhance clarity and readability without affecting functionality. The following changes were made:

- **Documentation**
  - Corrected a typographical error in the performance guidelines for improved clarity.
- **Style**
  - Refined text details by fixing minor grammatical issues to ensure a consistent and professional presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->