### PR TITLE
refactor: replace []byte(fmt.Sprintf) with fmt.Appendf

### DIFF
--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -47,13 +47,13 @@ var _ cache.Node = (*testNode)(nil)
 
 var testNodes = []cache.Node{
 	&testNode{
-		key: []byte(fmt.Sprintf("%s%d", testKey, 1)),
+		key: fmt.Appendf(nil, "%s%d", testKey, 1),
 	},
 	&testNode{
-		key: []byte(fmt.Sprintf("%s%d", testKey, 2)),
+		key: fmt.Appendf(nil, "%s%d", testKey, 2),
 	},
 	&testNode{
-		key: []byte(fmt.Sprintf("%s%d", testKey, 3)),
+		key: fmt.Appendf(nil, "%s%d", testKey, 3),
 	},
 }
 

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -74,7 +74,7 @@ func TestLazySet(t *testing.T) {
 	for i := 0; i < postVersions; i++ {
 		leafCount := rand.Intn(50)
 		for j := 0; j < leafCount; j++ {
-			_, err = tree.Set([]byte(fmt.Sprintf("key-%d-%d", i, j)), []byte(fmt.Sprintf("value-%d-%d", i, j)))
+			_, err = tree.Set(fmt.Appendf(nil, "key-%d-%d", i, j), fmt.Appendf(nil, "value-%d-%d", i, j))
 			require.NoError(t, err)
 		}
 		_, _, err = tree.SaveVersion()
@@ -157,7 +157,7 @@ func TestDeleteVersions(t *testing.T) {
 	for i := 0; i < postVersions; i++ {
 		leafCount := rand.Intn(10)
 		for j := 0; j < leafCount; j++ {
-			_, err = tree.Set([]byte(fmt.Sprintf("key-%d-%d", i, j)), []byte(fmt.Sprintf("value-%d-%d", i, j)))
+			_, err = tree.Set(fmt.Appendf(nil, "key-%d-%d", i, j), fmt.Appendf(nil, "value-%d-%d", i, j))
 			require.NoError(t, err)
 		}
 		_, _, err = tree.SaveVersion()
@@ -188,7 +188,7 @@ func TestDeleteVersions(t *testing.T) {
 	for i := 0; i < postVersions; i++ {
 		leafCount := rand.Intn(20)
 		for j := 0; j < leafCount; j++ {
-			_, err = tree.Set([]byte(fmt.Sprintf("key-%d-%d", i, j)), []byte(fmt.Sprintf("value-%d-%d", i, j)))
+			_, err = tree.Set(fmt.Appendf(nil, "key-%d-%d", i, j), fmt.Appendf(nil, "value-%d-%d", i, j))
 			require.NoError(t, err)
 		}
 		_, _, err = tree.SaveVersion()
@@ -242,7 +242,7 @@ func TestPruning(t *testing.T) {
 	pruningInterval := int64(20)
 	for i := int64(0); i < toVersion; i++ {
 		for j := 0; j < leavesCount; j++ {
-			_, err := tree.Set([]byte(fmt.Sprintf("key%d", j)), []byte(fmt.Sprintf("value%d", j)))
+			_, err := tree.Set(fmt.Appendf(nil, "key%d", j), fmt.Appendf(nil, "value%d", j))
 			require.NoError(t, err)
 		}
 		_, v, err := tree.SaveVersion()

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -49,7 +49,7 @@ func TestIterateConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func(i, j int) {
 				defer wg.Done()
-				_, err := tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), iavlrand.RandBytes(1))
+				_, err := tree.Set(fmt.Appendf(nil, "%d%d", i, j), iavlrand.RandBytes(1))
 				require.NoError(t, err)
 			}(i, j)
 		}
@@ -76,7 +76,7 @@ func TestIteratorConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func(i, j int) {
 				defer wg.Done()
-				_, err := tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), iavlrand.RandBytes(1))
+				_, err := tree.Set(fmt.Appendf(nil, "%d%d", i, j), iavlrand.RandBytes(1))
 				require.NoError(t, err)
 			}(i, j)
 		}
@@ -100,7 +100,7 @@ func TestNewIteratorConcurrency(t *testing.T) {
 			wg.Add(1)
 			go func(i, j int) {
 				defer wg.Done()
-				_, err := tree.Set([]byte(fmt.Sprintf("%d%d", i, j)), iavlrand.RandBytes(1))
+				_, err := tree.Set(fmt.Appendf(nil, "%d%d", i, j), iavlrand.RandBytes(1))
 				require.NoError(t, err)
 			}(i, j)
 		}
@@ -203,7 +203,7 @@ func TestTraverse(t *testing.T) {
 	tree := setupMutableTree(false)
 
 	for i := 0; i < 6; i++ {
-		_, err := tree.set([]byte(fmt.Sprintf("k%d", i)), []byte(fmt.Sprintf("v%d", i)))
+		_, err := tree.set(fmt.Appendf(nil, "k%d", i), fmt.Appendf(nil, "v%d", i))
 		require.NoError(t, err)
 	}
 

--- a/prune_test.go
+++ b/prune_test.go
@@ -22,7 +22,7 @@ func TestAsyncPruning(t *testing.T) {
 	keepRecent := int64(300)
 	for i := 0; i < toVersion; i++ {
 		for j := 0; j < keyCount; j++ {
-			_, err := tree.Set([]byte(fmt.Sprintf("key-%d-%d", i, j)), []byte(fmt.Sprintf("value-%d-%d", i, j)))
+			_, err := tree.Set(fmt.Appendf(nil, "key-%d-%d", i, j), fmt.Appendf(nil, "value-%d-%d", i, j))
 			require.NoError(t, err)
 		}
 

--- a/tree_test.go
+++ b/tree_test.go
@@ -1271,7 +1271,7 @@ func TestLoadVersion(t *testing.T) {
 	require.Equal(t, version, int64(0), "expected latest version to be zero")
 
 	for i := 0; i < maxVersions; i++ {
-		tree.Set([]byte(fmt.Sprintf("key_%d", i+1)), []byte(fmt.Sprintf("value_%d", i+1)))
+		tree.Set(fmt.Appendf(nil, "key_%d", i+1), fmt.Appendf(nil, "value_%d", i+1))
 
 		_, _, err = tree.SaveVersion()
 		require.NoError(t, err, "SaveVersion should not fail")
@@ -1282,18 +1282,18 @@ func TestLoadVersion(t *testing.T) {
 	require.NoError(t, err, "unexpected error when lazy loading version")
 	require.Equal(t, version, int64(maxVersions))
 
-	value, err := tree.Get([]byte(fmt.Sprintf("key_%d", maxVersions)))
+	value, err := tree.Get(fmt.Appendf(nil, "key_%d", maxVersions))
 	require.NoError(t, err)
-	require.Equal(t, value, []byte(fmt.Sprintf("value_%d", maxVersions)), "unexpected value")
+	require.Equal(t, value, fmt.Appendf(nil, "value_%d", maxVersions), "unexpected value")
 
 	// require the ability to load an older version
 	version, err = tree.LoadVersion(int64(maxVersions - 1))
 	require.NoError(t, err, "unexpected error when loading version")
 	require.Equal(t, version, int64(maxVersions))
 
-	value, err = tree.Get([]byte(fmt.Sprintf("key_%d", maxVersions-1)))
+	value, err = tree.Get(fmt.Appendf(nil, "key_%d", maxVersions-1))
 	require.NoError(t, err)
-	require.Equal(t, value, []byte(fmt.Sprintf("value_%d", maxVersions-1)), "unexpected value")
+	require.Equal(t, value, fmt.Appendf(nil, "value_%d", maxVersions-1), "unexpected value")
 
 	// require the inability to load a non-valid version
 	version, err = tree.LoadVersion(int64(maxVersions + 1))


### PR DESCRIPTION
replace []byte(fmt.Sprintf) with fmt.Appendf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved efficiency of test code by optimizing the way keys and values are constructed for various tests. No changes to test logic or outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->