### PR TITLE
docs: fix dead link

### DIFF
--- a/docs/architecture/adr-template.md
+++ b/docs/architecture/adr-template.md
@@ -8,7 +8,7 @@
 
 {DRAFT | PROPOSED} Not Implemented
 
-> Please have a look at the [PROCESS](./PROCESS.md#adr-status) page.
+> Please have a look at the [PROCESS](https://docs.cosmos.network/main/build/architecture/PROCESS) page.
 > Use DRAFT if the ADR is in a draft stage (draft PR) or PROPOSED if it's in review.
 
 ## Abstract


### PR DESCRIPTION
fixed 404 link to a correct one
https://docs.cosmos.network/main/build/architecture/PROCESS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the ADR template to reference the PROCESS documentation using an external web link instead of a local path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->