### PR TITLE
fix: typos and improve wording in documentation and test comments

### DIFF
--- a/docs/architecture/adr-001-node-key-refactoring.md
+++ b/docs/architecture/adr-001-node-key-refactoring.md
@@ -79,7 +79,7 @@ We can migrate nodes through the following steps:
 
 The current pruning strategies allows for intermediate versions to exist. With the adoption of this ADR we are migrating to allowing only versions to exist between a range (50-100 instead of 1,25,50-100).
 
-Here we are introducing a new way how to get orphaned nodes which remove in the `n+1`th version updates without storing orphanes in the storage.
+Here we are introducing a new way how to get orphaned nodes which remove in the `n+1`th version updates without storing orphans in the storage.
 
 When we want to remove the `n+1`th version
 
@@ -130,7 +130,7 @@ When we want to rollback to the specific version `n`
 * `Update` operations will require extra DB access because we need to take children to calculate the hash of updated nodes.
 	* It doesn't require more access in other cases including `Set`, `Remove`, and `Proof`.
 
-* It is impossible to remove the individual version. The new design requires more restrict pruning strategies.
+* It is impossible to remove the individual version. The new design requires more restricted pruning strategies.
 
 * When importing the tree, it may require more memory because of int32 array of the version length. We will introduce the new importing strategy to reduce the memory usage.
 

--- a/mutable_tree_test.go
+++ b/mutable_tree_test.go
@@ -974,7 +974,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	batchMock.EXPECT().Write().Return(nil).Times(1)
 	batchMock.EXPECT().Close().Return(nil).Times(1)
 
-	// iterMock is used to mock the underlying db iterator behing fast iterator
+	// iterMock is used to mock the underlying db iterator behind fast iterator
 	// Here, we want to mock the behavior of deleting fast nodes from disk when
 	// force upgrade is detected.
 	iterMock.EXPECT().Valid().Return(true).Times(1)
@@ -994,7 +994,7 @@ func TestFastStorageReUpgradeProtection_ForceUpgradeFirstTime_NoForceSecondTime_
 	iterMock.EXPECT().Next().Return().Times(1)
 	iterMock.EXPECT().Error().Return(nil).Times(1)
 	iterMock.EXPECT().Valid().Return(false).Times(1)
-	// Call Valid after first iteraton
+	// Call Valid after first iteration
 	iterMock.EXPECT().Valid().Return(false).Times(1)
 	iterMock.EXPECT().Close().Return(nil).Times(1)
 


### PR DESCRIPTION


**Description:**  
This pull request fixes minor typos and improves wording in both documentation and test comments:
- Corrects spelling mistakes in `adr-001-node-key-refactoring.md` (e.g., "orphanes" → "orphans", "restrict" → "restricted").
- Fixes typos in test comments in `mutable_tree_test.go` (e.g., "behing" → "behind", "iteraton" → "iteration").
- Enhances clarity and accuracy of comments and documentation without changing any code logic.

These changes help improve the overall readability and professionalism of the project. No functional code was affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected minor typographical errors in architecture documentation for improved clarity.
- **Style**
  - Fixed typos in code comments within tests to enhance readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->