### PR TITLE
Replace defer with explicit Close() calls in export/import loops

### DIFF
--- a/benchmarks/cosmos-exim/main.go
+++ b/benchmarks/cosmos-exim/main.go
@@ -126,7 +126,6 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 		if err != nil {
 			return 0, nil, err
 		}
-		defer exporter.Close()
 		for {
 			node, err := exporter.Next()
 			if errors.Is(err, iavl.ErrorExportDone) {
@@ -137,6 +136,7 @@ func runExport(dbPath string) (int64, map[string][]*iavl.ExportNode, error) {
 			export = append(export, node)
 			stats.AddNode(node)
 		}
+		exporter.Close()
 		stats.AddDurationSince(start)
 		fmt.Printf("%-13v: %v\n", name, stats.String())
 		totalStats.Add(stats)
@@ -173,7 +173,6 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 		if err != nil {
 			return err
 		}
-		defer importer.Close()
 		for _, node := range exports[name] {
 			err = importer.Add(node)
 			if err != nil {
@@ -185,6 +184,7 @@ func runImport(version int64, exports map[string][]*iavl.ExportNode) error {
 		if err != nil {
 			return err
 		}
+		importer.Close()
 		stats.AddDurationSince(start)
 		fmt.Printf("%-12v: %v\n", name, stats.String())
 		totalStats.Add(stats)


### PR DESCRIPTION
Replaced defer exporter.Close() and defer importer.Close() with explicit Close() calls inside the export and import loops for each store.

This change ensures that resources (such as file descriptors or handles) are released immediately after processing each store, rather than being held until the end of the entire function.

Using defer inside a loop causes all deferred calls to accumulate and execute only when the surrounding function returns, which can lead to excessive resource usage or even resource exhaustion if the number of stores is large.

Explicitly closing the exporter/importer after each store improves resource management and prevents potential leaks.