### PR TITLE
chore: v1.2.7 changelog & cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.2.6, March 27, 2025
+
+### Bug Fixes 
+
+- [#1067](https://github.com/cosmos/iavl/pull/1067) Fix get latest version in store after legacy pruning fails.
+
 ## 1.2.5, March 26, 2025
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.2.7, April 6, 2026
+
+### Bug Fixes
+
+- [#1142](https://github.com/cosmos/iavl/pull/1142) Fix race between updating fast node cache and db commit in `NodeDB`.
+
+### Improvements
+
+- [#1134](https://github.com/cosmos/iavl/pull/1134) Add open telemetry metric support.
+
 ## 1.2.6, March 27, 2025
 
 ### Bug Fixes 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.2.5, March 26, 2025
+
+### Bug Fixes
+
+- [#983](https://github.com/cosmos/iavl/pull/983) Wait for previous batch before writing batch on `importer.Commit`.
+- [#1063](https://github.com/cosmos/iavl/pull/1065) Continue pruning if version is not found.
+
+### Improvements
+
+- [#1029](https://github.com/cosmos/iavl/pull/1029) Improve `RootKey` cache in pruning, reducing `RootKey` fetches.
+
 ## 1.2.4 December 27, 2024
 
 - [#1026](https://github.com/cosmos/iavl/pull/1026)  Remove duplicated rootkey fetch when pruning
@@ -15,7 +26,6 @@
 ### Bug Fixes
 
 - [#1007](https://github.com/cosmos/iavl/pull/1007) Add the extra check for the reformatted root node in `GetNode`
-- [#1142](https://github.com/cosmos/iavl/pull/1142) Fix race between updating fast node cache and db commit in `NodeDB`.
 
 ## v1.2.1 July 31, 2024
 


### PR DESCRIPTION
also adds entries for v1.2.5 and v1.2.6 that were missing