### PR TITLE
fix: improve importer validation and validate bounds in compress importer and delta decoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#1007](https://github.com/cosmos/iavl/pull/1007) Add the extra check for the reformatted root node in `GetNode`
 - [#1142](https://github.com/cosmos/iavl/pull/1142) Fix race between updating fast node cache and db commit in `NodeDB`.
+- [#1153](https://github.com/cosmos/iavl/pull/1153) Improve `Importer` validation and validate bounds in `CompressImporter` and `deltaDecoder`.
 
 ### Improvements
 

--- a/compress.go
+++ b/compress.go
@@ -80,6 +80,12 @@ func (i *CompressImporter) Add(node *ExportNode) error {
 		i.minKeyStack = append(i.minKeyStack, key)
 		i.versionStack = append(i.versionStack, node.Version)
 	} else {
+		if len(i.minKeyStack) < 2 {
+			return fmt.Errorf("invalid node order: branch node requires two children on min-key stack, found %d", len(i.minKeyStack))
+		}
+		if len(i.versionStack) < 2 {
+			return fmt.Errorf("invalid node order: branch node requires two children on version stack, found %d", len(i.versionStack))
+		}
 		// use the min-key in right branch as the node key
 		node.Key = i.minKeyStack[len(i.minKeyStack)-1]
 		// leave the min-key in left branch in the stack
@@ -111,6 +117,10 @@ func deltaDecode(key, lastKey []byte) ([]byte, error) {
 	key = key[n:]
 	if shared == 0 {
 		return key, nil
+	}
+
+	if shared > uint64(len(lastKey)) {
+		return nil, fmt.Errorf("shared prefix length %d exceeds previous key length %d", shared, len(lastKey))
 	}
 
 	newKey := make([]byte, shared+uint64(len(key)))

--- a/compress_test.go
+++ b/compress_test.go
@@ -29,7 +29,7 @@ func TestDeltaDecode_SharedExceedsLastKey(t *testing.T) {
 	lastKey := []byte("ab")
 
 	var buf [binary.MaxVarintLen64]byte
-	n := binary.PutUvarint(buf[:], uint64(len(lastKey)+1))
+	n := binary.PutUvarint(buf[:], uint64(len(lastKey)+1)) //nolint: gosec
 	encoded := append(buf[:n], 'c')
 
 	_, err := deltaDecode(encoded, lastKey)

--- a/compress_test.go
+++ b/compress_test.go
@@ -1,0 +1,54 @@
+package iavl
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompressImporter_BranchBeforeLeaves(t *testing.T) {
+	importer := NewCompressImporter(&noopImporter{})
+	node := &ExportNode{Version: 1, Height: 1}
+	require.Error(t, importer.Add(node))
+}
+
+func TestCompressImporter_BranchAfterSingleLeaf(t *testing.T) {
+	importer := NewCompressImporter(&noopImporter{})
+
+	// delta encoded leaf key with shared=0 prefix
+	leafKey := append([]byte{0}, 'a')
+	node := &ExportNode{Key: leafKey, Value: []byte{1}, Version: 1, Height: 0}
+	require.NoError(t, importer.Add(node))
+
+	err := importer.Add(&ExportNode{Version: 1, Height: 1})
+	require.Error(t, err)
+}
+
+func TestDeltaDecode_SharedExceedsLastKey(t *testing.T) {
+	lastKey := []byte("ab")
+
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], uint64(len(lastKey)+1))
+	encoded := append(buf[:n], 'c')
+
+	_, err := deltaDecode(encoded, lastKey)
+	require.Error(t, err)
+}
+
+func TestDeltaDecode_LargeSharedValue(t *testing.T) {
+	lastKey := []byte("ab")
+
+	var buf [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(buf[:], 1<<40)
+	encoded := append(buf[:n], 'c')
+
+	_, err := deltaDecode(encoded, lastKey)
+	require.Error(t, err)
+}
+
+// noopImporter is a NodeImporter that records nothing — used to isolate
+// CompressImporter behavior from inner importer validation.
+type noopImporter struct{}
+
+func (*noopImporter) Add(*ExportNode) error { return nil }

--- a/import.go
+++ b/import.go
@@ -27,7 +27,7 @@ type Importer struct {
 	batch     store.Batch
 	batchSize uint32
 	stack     []*Node
-	nonces    []uint32
+	nonces    map[int64]uint32
 
 	// inflightCommit tracks a batch commit, if any.
 	inflightCommit <-chan error
@@ -53,7 +53,7 @@ func newImporter(tree *MutableTree, version int64) (*Importer, error) {
 		version: version,
 		batch:   tree.ndb.db.NewBatch(),
 		stack:   make([]*Node, 0, 8),
-		nonces:  make([]uint32, version+1),
+		nonces:  make(map[int64]uint32),
 	}, nil
 }
 

--- a/import.go
+++ b/import.go
@@ -131,6 +131,9 @@ func (i *Importer) Add(exportNode *ExportNode) error {
 		return fmt.Errorf("node version %v can't be greater than import version %v",
 			exportNode.Version, i.version)
 	}
+	if exportNode.Version < 0 {
+		return fmt.Errorf("node version %v can't be less than 0", exportNode.Version)
+	}
 
 	node := &Node{
 		key:           exportNode.Key,

--- a/import_test.go
+++ b/import_test.go
@@ -2,6 +2,7 @@ package iavl
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -74,6 +75,26 @@ func TestImporter_NegativeVersion(t *testing.T) {
 	tree := NewMutableTree(dbm.NewMemDB(), 0, false, NewNopLogger())
 	_, err := tree.Import(-1)
 	require.Error(t, err)
+}
+
+func TestImporter_Add_NegativeNodeVersion(t *testing.T) {
+	tree := NewMutableTree(dbm.NewMemDB(), 0, false, NewNopLogger())
+	importer, err := tree.Import(1)
+	require.NoError(t, err)
+	defer importer.Close()
+
+	node := &ExportNode{Key: []byte("key"), Value: []byte("value"), Version: -1, Height: 0}
+	require.Error(t, importer.Add(node))
+}
+
+func TestImporter_LargeVersion(t *testing.T) {
+	tree := NewMutableTree(dbm.NewMemDB(), 0, false, NewNopLogger())
+	importer, err := tree.Import(math.MaxInt64)
+	require.NoError(t, err)
+	defer importer.Close()
+
+	node := &ExportNode{Key: []byte("key"), Value: []byte("value"), Version: math.MaxInt64, Height: 0}
+	require.NoError(t, importer.Add(node))
 }
 
 func TestImporter_NotEmpty(t *testing.T) {


### PR DESCRIPTION
Adds extra validation for different cases in the importer, compress importer, and delta decoder