### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/internal/color/colors.go
+++ b/internal/color/colors.go
@@ -25,7 +25,7 @@ func treat(s string, color string) string {
 	return color + s + ANSIReset
 }
 
-func treatAll(color string, args ...interface{}) string {
+func treatAll(color string, args ...any) string {
 	parts := make([]string, 0, len(args))
 	for _, arg := range args {
 		parts = append(parts, treat(fmt.Sprintf("%v", arg), color))
@@ -33,22 +33,22 @@ func treatAll(color string, args ...interface{}) string {
 	return strings.Join(parts, "")
 }
 
-func Green(args ...interface{}) string {
+func Green(args ...any) string {
 	return treatAll(ANSIFgGreen, args...)
 }
 
-func Blue(args ...interface{}) string {
+func Blue(args ...any) string {
 	return treatAll(ANSIFgBlue, args...)
 }
 
-func Cyan(args ...interface{}) string {
+func Cyan(args ...any) string {
 	return treatAll(ANSIFgCyan, args...)
 }
 
 // ColoredBytes takes in the byte that you would like to show as a string and byte
 // and will display them in a human readable format.
 // If the environment variable TENDERMINT_IAVL_COLORS_ON is set to a non-empty string then different colors will be used for bytes and strings.
-func ColoredBytes(data []byte, textColor, bytesColor func(...interface{}) string) string {
+func ColoredBytes(data []byte, textColor, bytesColor func(...any) string) string {
 	colors := os.Getenv("TENDERMINT_IAVL_COLORS_ON")
 	if colors == "" {
 		return string(data)

--- a/internal/encoding/encoding.go
+++ b/internal/encoding/encoding.go
@@ -11,19 +11,19 @@ import (
 )
 
 var bufPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }
 
 var varintPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &[binary.MaxVarintLen64]byte{}
 	},
 }
 
 var uvarintPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &[binary.MaxVarintLen64]byte{}
 	},
 }

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -375,7 +375,7 @@ func TestNodeIterator_WithEmptyRoot(t *testing.T) {
 
 func syncMapCount(m *sync.Map) int {
 	count := 0
-	m.Range(func(_, _ interface{}) bool {
+	m.Range(func(_, _ any) bool {
 		count++
 		return true
 	})

--- a/keyformat/key_format.go
+++ b/keyformat/key_format.go
@@ -96,7 +96,7 @@ func (kf *KeyFormat) KeyBytes(segments ...[]byte) []byte {
 // Format the args passed into the key format - will panic if the arguments passed do not match the length
 // of the segment to which they correspond. When called with no arguments returns the raw prefix (useful as a start
 // element of the entire keys space when sorted lexicographically).
-func (kf *KeyFormat) Key(args ...interface{}) []byte {
+func (kf *KeyFormat) Key(args ...any) []byte {
 	if len(args) > len(kf.layout) {
 		panic(fmt.Errorf("keyFormat.Key() is provided with %d args but format only has %d segments",
 			len(args), len(kf.layout)))
@@ -130,7 +130,7 @@ func (kf *KeyFormat) ScanBytes(key []byte) [][]byte {
 
 // Extracts the segments into the values pointed to by each of args. Each arg must be a pointer to int64, uint64, or
 // []byte, and the width of the args must match layout.
-func (kf *KeyFormat) Scan(key []byte, args ...interface{}) {
+func (kf *KeyFormat) Scan(key []byte, args ...any) {
 	segments := kf.ScanBytes(key)
 	if len(args) > len(segments) {
 		panic(fmt.Errorf("keyFormat.Scan() is provided with %d args but format only has %d segments in key %X",
@@ -151,7 +151,7 @@ func (kf *KeyFormat) Prefix() string {
 	return string([]byte{kf.prefix})
 }
 
-func scan(a interface{}, value []byte) {
+func scan(a any, value []byte) {
 	switch v := a.(type) {
 	case *int64:
 		// Negative values will be mapped correctly when read in as uint64 and then type converted
@@ -171,7 +171,7 @@ func scan(a interface{}, value []byte) {
 	}
 }
 
-func format(a interface{}) []byte {
+func format(a any) []byte {
 	switch v := a.(type) {
 	case uint64:
 		return formatUint64(v)

--- a/keyformat/prefix_formatter.go
+++ b/keyformat/prefix_formatter.go
@@ -22,7 +22,7 @@ func (f *FastPrefixFormatter) Key(bz []byte) []byte {
 	return key
 }
 
-func (f *FastPrefixFormatter) Scan(key []byte, a interface{}) {
+func (f *FastPrefixFormatter) Scan(key []byte, a any) {
 	scan(a, key[1:])
 }
 

--- a/mutable_tree.go
+++ b/mutable_tree.go
@@ -37,7 +37,7 @@ type MutableTree struct {
 	*ImmutableTree                          // The current, working tree.
 	lastSaved                *ImmutableTree // The most recently saved tree.
 	unsavedFastNodeAdditions *sync.Map      // map[string]*FastNode FastNodes that have not yet been saved to disk
-	unsavedFastNodeRemovals  *sync.Map      // map[string]interface{} FastNodes that have not yet been removed from disk
+	unsavedFastNodeRemovals  *sync.Map      // map[string]any FastNodes that have not yet been removed from disk
 	ndb                      *nodeDB
 	skipFastStorageUpgrade   bool // If true, the tree will work like no fast storage and always not upgrade fast storage
 	initialVersionSet        bool
@@ -803,7 +803,7 @@ func (tree *MutableTree) saveFastNodeVersion(latestVersion int64) error {
 
 func (tree *MutableTree) getUnsavedFastNodeAdditions() map[string]*fastnode.Node {
 	additions := make(map[string]*fastnode.Node)
-	tree.unsavedFastNodeAdditions.Range(func(key, value interface{}) bool {
+	tree.unsavedFastNodeAdditions.Range(func(key, value any) bool {
 		additions[key.(string)] = value.(*fastnode.Node)
 		return true
 	})
@@ -812,9 +812,9 @@ func (tree *MutableTree) getUnsavedFastNodeAdditions() map[string]*fastnode.Node
 
 // getUnsavedFastNodeRemovals returns unsaved FastNodes to remove
 
-func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]interface{} {
-	removals := make(map[string]interface{})
-	tree.unsavedFastNodeRemovals.Range(func(key, value interface{}) bool {
+func (tree *MutableTree) getUnsavedFastNodeRemovals() map[string]any {
+	removals := make(map[string]any)
+	tree.unsavedFastNodeRemovals.Range(func(key, value any) bool {
 		removals[key.(string)] = value
 		return true
 	})
@@ -830,7 +830,7 @@ func (tree *MutableTree) addUnsavedAddition(key []byte, node *fastnode.Node) {
 
 func (tree *MutableTree) saveFastNodeAdditions() error {
 	keysToSort := make([]string, 0)
-	tree.unsavedFastNodeAdditions.Range(func(k, _ interface{}) bool {
+	tree.unsavedFastNodeAdditions.Range(func(k, _ any) bool {
 		keysToSort = append(keysToSort, k.(string))
 		return true
 	})
@@ -854,7 +854,7 @@ func (tree *MutableTree) addUnsavedRemoval(key []byte) {
 
 func (tree *MutableTree) saveFastNodeRemovals() error {
 	keysToSort := make([]string, 0)
-	tree.unsavedFastNodeRemovals.Range(func(k, _ interface{}) bool {
+	tree.unsavedFastNodeRemovals.Range(func(k, _ any) bool {
 		keysToSort = append(keysToSort, k.(string))
 		return true
 	})

--- a/nodedb_test.go
+++ b/nodedb_test.go
@@ -41,7 +41,7 @@ func BenchmarkTreeString(b *testing.B) {
 	if sink == nil {
 		b.Fatal("Benchmark did not run")
 	}
-	sink = (interface{})(nil)
+	sink = (any)(nil)
 }
 
 func TestNewNoDbStorage_StorageVersionInDb_Success(t *testing.T) {

--- a/proof.go
+++ b/proof.go
@@ -12,7 +12,7 @@ import (
 )
 
 var bufPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }

--- a/proof_ics23_test.go
+++ b/proof_ics23_test.go
@@ -227,7 +227,7 @@ func BuildTree(size int, cacheSize int) (itree *MutableTree, keys [][]byte, err 
 
 // sink is kept as a global to ensure that value checks and assignments to it can't be
 // optimized away, and this will help us ensure that benchmarks successfully run.
-var sink interface{}
+var sink any
 
 func BenchmarkConvertLeafOp(b *testing.B) {
 	versions := []int64{

--- a/testutils_test.go
+++ b/testutils_test.go
@@ -47,7 +47,7 @@ func getTestTree(cacheSize int) *MutableTree {
 }
 
 // Convenience for a new node
-func N(l, r interface{}) *Node {
+func N(l, r any) *Node {
 	var left, right *Node
 	if _, ok := l.(*Node); ok {
 		left = l.(*Node)

--- a/unsaved_fast_iterator.go
+++ b/unsaved_fast_iterator.go
@@ -32,7 +32,7 @@ type UnsavedFastIterator struct {
 
 	nextUnsavedNodeIdx       int
 	unsavedFastNodeAdditions *sync.Map // map[string]*FastNode
-	unsavedFastNodeRemovals  *sync.Map // map[string]interface{}
+	unsavedFastNodeRemovals  *sync.Map // map[string]any
 	unsavedFastNodesToSort   []string
 }
 
@@ -72,7 +72,7 @@ func NewUnsavedFastIterator(start, end []byte, ascending bool, ndb *nodeDB, unsa
 	// We need to ensure that we iterate over saved and unsaved state in order.
 	// The strategy is to sort unsaved nodes, the fast node on disk are already sorted.
 	// Then, we keep a pointer to both the unsaved and saved nodes, and iterate over them in order efficiently.
-	unsavedFastNodeAdditions.Range(func(k, v interface{}) bool {
+	unsavedFastNodeAdditions.Range(func(k, v any) bool {
 		fastNode := v.(*fastnode.Node)
 
 		if start != nil && bytes.Compare(fastNode.GetKey(), start) < 0 {

--- a/v2/internal/encoding.go
+++ b/v2/internal/encoding.go
@@ -11,19 +11,19 @@ import (
 )
 
 var bufPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(bytes.Buffer)
 	},
 }
 
 var varintPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &[binary.MaxVarintLen64]byte{}
 	},
 }
 
 var uvarintPool = &sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return &[binary.MaxVarintLen64]byte{}
 	},
 }

--- a/v2/pool.go
+++ b/v2/pool.go
@@ -17,7 +17,7 @@ type NodePool struct {
 func NewNodePool() *NodePool {
 	np := &NodePool{
 		syncPool: &sync.Pool{
-			New: func() interface{} {
+			New: func() any {
 				return &Node{}
 			},
 		},

--- a/v2/sqlite.go
+++ b/v2/sqlite.go
@@ -944,7 +944,7 @@ func (sql *SqliteDb) replayChangelog(tree *Tree, toVersion int64, targetHash []b
 		count       int64
 		start       = time.Now()
 		since       = time.Now()
-		logPath     = []interface{}{"path", sql.opts.Path}
+		logPath     = []any{"path", sql.opts.Path}
 	)
 	tree.isReplaying = true
 	defer func() {


### PR DESCRIPTION
Replace `interface{}` with `any` (Go 1.18+ shorthand) across the codebase.

- 14 Go files updated
- No functional changes