### PR TITLE
fix(keyformat): validate KeyBytes segment count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+- Return a clear `KeyFormat.KeyBytes` panic when too many segments are provided.
+
 ### Improvements
 
 ## v1.3.6, April 6, 2026

--- a/keyformat/key_format.go
+++ b/keyformat/key_format.go
@@ -52,6 +52,11 @@ func NewKeyFormat(prefix byte, layout ...int) *KeyFormat {
 
 // Format the byte segments into the key format - will panic if the segment lengths do not match the layout.
 func (kf *KeyFormat) KeyBytes(segments ...[]byte) []byte {
+	if len(segments) > len(kf.layout) {
+		panic(fmt.Errorf("keyFormat.KeyBytes() is provided with %d segments but format only has %d segments",
+			len(segments), len(kf.layout)))
+	}
+
 	keyLen := kf.length
 	// In case segments length is less than layouts length,
 	// we don't have to allocate the whole kf.length, just

--- a/keyformat/key_format_test.go
+++ b/keyformat/key_format_test.go
@@ -62,6 +62,18 @@ func TestKeyFormatBytes(t *testing.T) {
 	}
 }
 
+func TestKeyFormatBytesPanicsWithTooManySegments(t *testing.T) {
+	kf := NewKeyFormat(byte('e'))
+
+	assert.PanicsWithError(
+		t,
+		"keyFormat.KeyBytes() is provided with 1 segments but format only has 0 segments",
+		func() {
+			kf.KeyBytes([]byte{1})
+		},
+	)
+}
+
 func TestKeyFormat(t *testing.T) {
 	kf := NewKeyFormat(byte('e'), 8, 8, 8)
 	key := []byte{'e', 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 200, 0, 0, 0, 0, 0, 0, 1, 144}


### PR DESCRIPTION
## Summary

- Validate that `KeyFormat.KeyBytes` is not called with more segments than the key format layout supports.
- Return a clear `KeyFormat.KeyBytes` panic instead of a runtime index-out-of-range panic.
- Add a regression test for the zero-layout case.
- Add an Unreleased changelog entry.

## Motivation

`KeyFormat.Key` already checks for too many arguments before formatting. `KeyBytes` did not have the equivalent guard, so calling it with more byte segments than the layout length could panic with a low-level bounds error.

Fixes #760.

## Testing

- `go test ./keyformat -count=1`
- `make legacydump && go test ./... -count=1`
- `git diff --check`